### PR TITLE
[Feature] 로그인 및 추가 정보 기입 API를 구현한다

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -16,3 +16,27 @@ include::{snippets}/TokenReissueApi/Success/request-headers.adoc[]
 
 include::{snippets}/TokenReissueApi/Failure/http-response.adoc[]
 include::{snippets}/TokenReissueApi/Success/http-response.adoc[]
+
+== 로그인/로그아웃 API
+
+=== 로그인
+
+==== HTTP Request
+
+include::{snippets}/AuthApi/Login/http-request.adoc[]
+include::{snippets}/AuthApi/Login/request-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/AuthApi/Login/http-response.adoc[]
+include::{snippets}/AuthApi/Login/response-fields.adoc[]
+
+=== 로그아웃
+
+==== HTTP Request
+
+include::{snippets}/AuthApi/Logout/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/AuthApi/Logout/http-response.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -31,7 +31,7 @@ include::{snippets}/AuthApi/Login/request-fields.adoc[]
 include::{snippets}/AuthApi/Login/http-response.adoc[]
 include::{snippets}/AuthApi/Login/response-fields.adoc[]
 
-=== 로그아웃
+=== 로그아웃 (AccessToken)
 
 ==== HTTP Request
 
@@ -40,3 +40,28 @@ include::{snippets}/AuthApi/Logout/http-request.adoc[]
 ==== HTTP Response
 
 include::{snippets}/AuthApi/Logout/http-response.adoc[]
+
+== 온보딩 관련
+
+=== 닉네임 중복체크
+
+==== HTTP Request
+
+include::{snippets}/MemberApi/Onboarding/CheckNickname/http-request.adoc[]
+include::{snippets}/MemberApi/Onboarding/CheckNickname/query-parameters.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/MemberApi/Onboarding/CheckNickname/http-response.adoc[]
+include::{snippets}/MemberApi/Onboarding/CheckNickname/response-fields.adoc[]
+
+=== 추가 정보 기입 (AccessToken)
+
+==== HTTP Request
+
+include::{snippets}/MemberApi/Onboarding/CompleteInfo/http-request.adoc[]
+include::{snippets}/MemberApi/Onboarding/CompleteInfo/request-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/MemberApi/Onboarding/CompleteInfo/http-response.adoc[]

--- a/src/main/java/ac/dnd/bookkeeping/server/auth/application/usecase/LoginUseCase.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/auth/application/usecase/LoginUseCase.java
@@ -31,12 +31,12 @@ public class LoginUseCase {
     private LoginResponse createMemberAndIssueToken(final LoginCommand command) {
         final Member member = memberRepository.save(command.toDomain());
         final AuthToken token = tokenIssuer.provideAuthorityToken(member.getId());
-        return LoginResponse.of(true, member, token);
+        return LoginResponse.of(true, token);
     }
 
     private LoginResponse issueToken(final Member member, final SocialPlatform platform) {
         member.syncEmail(platform.getEmail());
         final AuthToken token = tokenIssuer.provideAuthorityToken(member.getId());
-        return LoginResponse.of(false, member, token);
+        return LoginResponse.of(false, token);
     }
 }

--- a/src/main/java/ac/dnd/bookkeeping/server/auth/application/usecase/LoginUseCase.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/auth/application/usecase/LoginUseCase.java
@@ -1,0 +1,42 @@
+package ac.dnd.bookkeeping.server.auth.application.usecase;
+
+import ac.dnd.bookkeeping.server.auth.application.usecase.command.LoginCommand;
+import ac.dnd.bookkeeping.server.auth.application.usecase.command.response.LoginResponse;
+import ac.dnd.bookkeeping.server.auth.domain.model.AuthToken;
+import ac.dnd.bookkeeping.server.auth.domain.service.TokenIssuer;
+import ac.dnd.bookkeeping.server.global.annotation.UseCase;
+import ac.dnd.bookkeeping.server.global.annotation.WritableTransactional;
+import ac.dnd.bookkeeping.server.member.domain.model.Member;
+import ac.dnd.bookkeeping.server.member.domain.model.SocialPlatform;
+import ac.dnd.bookkeeping.server.member.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+@UseCase
+@RequiredArgsConstructor
+public class LoginUseCase {
+    private final MemberRepository memberRepository;
+    private final TokenIssuer tokenIssuer;
+
+    @WritableTransactional
+    public LoginResponse invoke(final LoginCommand command) {
+        final Optional<Member> member = memberRepository.findByPlatformSocialId(command.platform().getSocialId());
+        if (member.isEmpty()) {
+            return createMemberAndIssueToken(command);
+        }
+        return issueToken(member.get(), command.platform());
+    }
+
+    private LoginResponse createMemberAndIssueToken(final LoginCommand command) {
+        final Member member = memberRepository.save(command.toDomain());
+        final AuthToken token = tokenIssuer.provideAuthorityToken(member.getId());
+        return LoginResponse.of(true, member, token);
+    }
+
+    private LoginResponse issueToken(final Member member, final SocialPlatform platform) {
+        member.syncEmail(platform.getEmail());
+        final AuthToken token = tokenIssuer.provideAuthorityToken(member.getId());
+        return LoginResponse.of(false, member, token);
+    }
+}

--- a/src/main/java/ac/dnd/bookkeeping/server/auth/application/usecase/LogoutUseCase.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/auth/application/usecase/LogoutUseCase.java
@@ -1,0 +1,20 @@
+package ac.dnd.bookkeeping.server.auth.application.usecase;
+
+import ac.dnd.bookkeeping.server.auth.application.usecase.command.LogoutCommand;
+import ac.dnd.bookkeeping.server.auth.domain.service.TokenIssuer;
+import ac.dnd.bookkeeping.server.global.annotation.UseCase;
+import ac.dnd.bookkeeping.server.member.domain.model.Member;
+import ac.dnd.bookkeeping.server.member.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class LogoutUseCase {
+    private final MemberRepository memberRepository;
+    private final TokenIssuer tokenIssuer;
+
+    public void invoke(final LogoutCommand command) {
+        final Member member = memberRepository.getById(command.memberId());
+        tokenIssuer.deleteRefreshToken(member.getId());
+    }
+}

--- a/src/main/java/ac/dnd/bookkeeping/server/auth/application/usecase/command/LoginCommand.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/auth/application/usecase/command/LoginCommand.java
@@ -1,0 +1,13 @@
+package ac.dnd.bookkeeping.server.auth.application.usecase.command;
+
+import ac.dnd.bookkeeping.server.member.domain.model.Member;
+import ac.dnd.bookkeeping.server.member.domain.model.SocialPlatform;
+
+public record LoginCommand(
+        SocialPlatform platform,
+        String name
+) {
+    public Member toDomain() {
+        return new Member(platform, name);
+    }
+}

--- a/src/main/java/ac/dnd/bookkeeping/server/auth/application/usecase/command/LoginCommand.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/auth/application/usecase/command/LoginCommand.java
@@ -3,11 +3,15 @@ package ac.dnd.bookkeeping.server.auth.application.usecase.command;
 import ac.dnd.bookkeeping.server.member.domain.model.Member;
 import ac.dnd.bookkeeping.server.member.domain.model.SocialPlatform;
 
+import java.time.LocalDate;
+
 public record LoginCommand(
         SocialPlatform platform,
-        String name
+        String name,
+        Member.Gender gender,
+        LocalDate birth
 ) {
     public Member toDomain() {
-        return new Member(platform, name);
+        return new Member(platform, name, gender, birth);
     }
 }

--- a/src/main/java/ac/dnd/bookkeeping/server/auth/application/usecase/command/LoginCommand.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/auth/application/usecase/command/LoginCommand.java
@@ -3,15 +3,11 @@ package ac.dnd.bookkeeping.server.auth.application.usecase.command;
 import ac.dnd.bookkeeping.server.member.domain.model.Member;
 import ac.dnd.bookkeeping.server.member.domain.model.SocialPlatform;
 
-import java.time.LocalDate;
-
 public record LoginCommand(
         SocialPlatform platform,
-        String name,
-        Member.Gender gender,
-        LocalDate birth
+        String profileImageUrl
 ) {
     public Member toDomain() {
-        return new Member(platform, name, gender, birth);
+        return Member.create(platform, profileImageUrl);
     }
 }

--- a/src/main/java/ac/dnd/bookkeeping/server/auth/application/usecase/command/LogoutCommand.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/auth/application/usecase/command/LogoutCommand.java
@@ -1,0 +1,6 @@
+package ac.dnd.bookkeeping.server.auth.application.usecase.command;
+
+public record LogoutCommand(
+        long memberId
+) {
+}

--- a/src/main/java/ac/dnd/bookkeeping/server/auth/application/usecase/command/response/LoginResponse.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/auth/application/usecase/command/response/LoginResponse.java
@@ -1,45 +1,13 @@
 package ac.dnd.bookkeeping.server.auth.application.usecase.command.response;
 
 import ac.dnd.bookkeeping.server.auth.domain.model.AuthToken;
-import ac.dnd.bookkeeping.server.member.domain.model.Member;
-
-import java.time.LocalDate;
 
 public record LoginResponse(
         boolean isNew,
-        MemberInfo info,
-        AuthToken token
+        String accessToken,
+        String refreshToken
 ) {
-    public record MemberInfo(
-            String name,
-            String gender,
-            LocalDate birth
-    ) {
-        public static MemberInfo of(final Member member) {
-            return new MemberInfo(
-                    member.getName(),
-                    convertGender(member.getGender()),
-                    member.getBirth()
-            );
-        }
-
-        private static String convertGender(final Member.Gender gender) {
-            if (gender == null) {
-                return null;
-            }
-            return gender.getValue();
-        }
-    }
-
-    public static LoginResponse of(
-            final boolean isNew,
-            final Member member,
-            final AuthToken token
-    ) {
-        return new LoginResponse(
-                isNew,
-                MemberInfo.of(member),
-                token
-        );
+    public static LoginResponse of(final boolean isNew, final AuthToken token) {
+        return new LoginResponse(isNew, token.accessToken(), token.refreshToken());
     }
 }

--- a/src/main/java/ac/dnd/bookkeeping/server/auth/application/usecase/command/response/LoginResponse.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/auth/application/usecase/command/response/LoginResponse.java
@@ -1,0 +1,30 @@
+package ac.dnd.bookkeeping.server.auth.application.usecase.command.response;
+
+import ac.dnd.bookkeeping.server.auth.domain.model.AuthToken;
+import ac.dnd.bookkeeping.server.member.domain.model.Member;
+
+public record LoginResponse(
+        boolean isNew,
+        MemberInfo info,
+        AuthToken token
+) {
+    public record MemberInfo(
+            String name
+    ) {
+        public MemberInfo(final Member member) {
+            this(member.getName());
+        }
+    }
+
+    public static LoginResponse of(
+            final boolean isNew,
+            final Member member,
+            final AuthToken token
+    ) {
+        return new LoginResponse(
+                isNew,
+                new MemberInfo(member),
+                token
+        );
+    }
+}

--- a/src/main/java/ac/dnd/bookkeeping/server/auth/application/usecase/command/response/LoginResponse.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/auth/application/usecase/command/response/LoginResponse.java
@@ -3,16 +3,31 @@ package ac.dnd.bookkeeping.server.auth.application.usecase.command.response;
 import ac.dnd.bookkeeping.server.auth.domain.model.AuthToken;
 import ac.dnd.bookkeeping.server.member.domain.model.Member;
 
+import java.time.LocalDate;
+
 public record LoginResponse(
         boolean isNew,
         MemberInfo info,
         AuthToken token
 ) {
     public record MemberInfo(
-            String name
+            String name,
+            String gender,
+            LocalDate birth
     ) {
-        public MemberInfo(final Member member) {
-            this(member.getName());
+        public static MemberInfo of(final Member member) {
+            return new MemberInfo(
+                    member.getName(),
+                    convertGender(member.getGender()),
+                    member.getBirth()
+            );
+        }
+
+        private static String convertGender(final Member.Gender gender) {
+            if (gender == null) {
+                return null;
+            }
+            return gender.getValue();
         }
     }
 
@@ -23,7 +38,7 @@ public record LoginResponse(
     ) {
         return new LoginResponse(
                 isNew,
-                new MemberInfo(member),
+                MemberInfo.of(member),
                 token
         );
     }

--- a/src/main/java/ac/dnd/bookkeeping/server/auth/presentation/AuthApiController.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/auth/presentation/AuthApiController.java
@@ -1,0 +1,47 @@
+package ac.dnd.bookkeeping.server.auth.presentation;
+
+import ac.dnd.bookkeeping.server.auth.application.usecase.LoginUseCase;
+import ac.dnd.bookkeeping.server.auth.application.usecase.LogoutUseCase;
+import ac.dnd.bookkeeping.server.auth.application.usecase.command.LoginCommand;
+import ac.dnd.bookkeeping.server.auth.application.usecase.command.LogoutCommand;
+import ac.dnd.bookkeeping.server.auth.application.usecase.command.response.LoginResponse;
+import ac.dnd.bookkeeping.server.auth.domain.model.Authenticated;
+import ac.dnd.bookkeeping.server.auth.presentation.dto.request.LoginRequest;
+import ac.dnd.bookkeeping.server.global.annotation.Auth;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "로그인/로그아웃 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class AuthApiController {
+    private final LoginUseCase loginUseCase;
+    private final LogoutUseCase logoutUseCase;
+
+    @Operation(summary = "로그인 Endpoint")
+    @PostMapping("/v1/auth/login")
+    public ResponseEntity<LoginResponse> login(
+            @RequestBody @Valid final LoginRequest request
+    ) {
+        final LoginResponse response = loginUseCase.invoke(new LoginCommand(
+                request.toSocialPlatform(),
+                request.name()
+        ));
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "로그아웃 EndPoint")
+    @PostMapping("/v1/auth/logout")
+    public ResponseEntity<Void> logout(@Auth final Authenticated authenticated) {
+        logoutUseCase.invoke(new LogoutCommand(authenticated.id()));
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/ac/dnd/bookkeeping/server/auth/presentation/AuthApiController.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/auth/presentation/AuthApiController.java
@@ -33,9 +33,7 @@ public class AuthApiController {
     ) {
         final LoginResponse response = loginUseCase.invoke(new LoginCommand(
                 request.toSocialPlatform(),
-                request.name(),
-                request.toGender(),
-                request.birth()
+                request.profileImageUrl()
         ));
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/ac/dnd/bookkeeping/server/auth/presentation/AuthApiController.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/auth/presentation/AuthApiController.java
@@ -33,7 +33,9 @@ public class AuthApiController {
     ) {
         final LoginResponse response = loginUseCase.invoke(new LoginCommand(
                 request.toSocialPlatform(),
-                request.name()
+                request.name(),
+                request.toGender(),
+                request.birth()
         ));
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/ac/dnd/bookkeeping/server/auth/presentation/TokenReissueApiController.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/auth/presentation/TokenReissueApiController.java
@@ -17,12 +17,12 @@ import static ac.dnd.bookkeeping.server.auth.domain.model.TokenType.REFRESH;
 @Tag(name = "토큰 재발급 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/token/reissue")
+@RequestMapping("/api")
 public class TokenReissueApiController {
     private final ReissueTokenUseCase reissueTokenUseCase;
 
     @Operation(summary = "RefreshToken을 통한 토큰 재발급 Endpoint")
-    @PostMapping
+    @PostMapping("/v1/token/reissue")
     public ResponseEntity<AuthToken> reissueToken(
             @ExtractToken(tokenType = REFRESH) final String refreshToken
     ) {

--- a/src/main/java/ac/dnd/bookkeeping/server/auth/presentation/dto/request/LoginRequest.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/auth/presentation/dto/request/LoginRequest.java
@@ -1,0 +1,20 @@
+package ac.dnd.bookkeeping.server.auth.presentation.dto.request;
+
+import ac.dnd.bookkeeping.server.member.domain.model.Email;
+import ac.dnd.bookkeeping.server.member.domain.model.SocialPlatform;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank(message = "소셜 플랫폼 ID는 필수입니다.")
+        String socialId,
+
+        @NotBlank(message = "소셜 플랫폼 이메일은 필수입니다.")
+        String email,
+
+        @NotBlank(message = "소셜 플랫폼 사용자 이름은 필수입니다.")
+        String name
+) {
+    public SocialPlatform toSocialPlatform() {
+        return SocialPlatform.of(socialId, Email.from(email));
+    }
+}

--- a/src/main/java/ac/dnd/bookkeeping/server/auth/presentation/dto/request/LoginRequest.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/auth/presentation/dto/request/LoginRequest.java
@@ -1,12 +1,8 @@
 package ac.dnd.bookkeeping.server.auth.presentation.dto.request;
 
 import ac.dnd.bookkeeping.server.member.domain.model.Email;
-import ac.dnd.bookkeeping.server.member.domain.model.Member;
 import ac.dnd.bookkeeping.server.member.domain.model.SocialPlatform;
 import jakarta.validation.constraints.NotBlank;
-import org.springframework.util.StringUtils;
-
-import java.time.LocalDate;
 
 public record LoginRequest(
         @NotBlank(message = "소셜 플랫폼 ID는 필수입니다.")
@@ -15,21 +11,10 @@ public record LoginRequest(
         @NotBlank(message = "소셜 플랫폼 이메일은 필수입니다.")
         String email,
 
-        @NotBlank(message = "소셜 플랫폼 사용자 이름은 필수입니다.")
-        String name,
-
-        String gender,
-
-        LocalDate birth
+        @NotBlank(message = "소셜 플랫폼 사용자 이미지 URL은 필수입니다.")
+        String profileImageUrl
 ) {
     public SocialPlatform toSocialPlatform() {
         return SocialPlatform.of(socialId, Email.from(email));
-    }
-
-    public Member.Gender toGender() {
-        if (!StringUtils.hasText(gender)) {
-            return null;
-        }
-        return Member.Gender.from(gender);
     }
 }

--- a/src/main/java/ac/dnd/bookkeeping/server/auth/presentation/dto/request/LoginRequest.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/auth/presentation/dto/request/LoginRequest.java
@@ -1,8 +1,12 @@
 package ac.dnd.bookkeeping.server.auth.presentation.dto.request;
 
 import ac.dnd.bookkeeping.server.member.domain.model.Email;
+import ac.dnd.bookkeeping.server.member.domain.model.Member;
 import ac.dnd.bookkeeping.server.member.domain.model.SocialPlatform;
 import jakarta.validation.constraints.NotBlank;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDate;
 
 public record LoginRequest(
         @NotBlank(message = "소셜 플랫폼 ID는 필수입니다.")
@@ -12,9 +16,20 @@ public record LoginRequest(
         String email,
 
         @NotBlank(message = "소셜 플랫폼 사용자 이름은 필수입니다.")
-        String name
+        String name,
+
+        String gender,
+
+        LocalDate birth
 ) {
     public SocialPlatform toSocialPlatform() {
         return SocialPlatform.of(socialId, Email.from(email));
+    }
+
+    public Member.Gender toGender() {
+        if (!StringUtils.hasText(gender)) {
+            return null;
+        }
+        return Member.Gender.from(gender);
     }
 }

--- a/src/main/java/ac/dnd/bookkeeping/server/global/base/BaseEntity.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/global/base/BaseEntity.java
@@ -2,14 +2,12 @@ package ac.dnd.bookkeeping.server.global.base;
 
 import com.google.common.annotations.VisibleForTesting;
 import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import lombok.Getter;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -17,19 +15,28 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Getter
 @MappedSuperclass
-@EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity<T> {
     @Id
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
-    @CreatedDate
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
-    @LastModifiedDate
     @Column(name = "last_modified_at")
     private LocalDateTime lastModifiedAt;
+
+    @PrePersist
+    void prePersist() {
+        final LocalDateTime now = LocalDateTime.now();
+        createdAt = now;
+        lastModifiedAt = now;
+    }
+
+    @PreUpdate
+    void preUpdate() {
+        lastModifiedAt = LocalDateTime.now();
+    }
 
     @SuppressWarnings("unchecked")
     @VisibleForTesting

--- a/src/main/java/ac/dnd/bookkeeping/server/member/application/usecase/CompleteInfoUseCase.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/application/usecase/CompleteInfoUseCase.java
@@ -15,6 +15,6 @@ public class CompleteInfoUseCase {
     @WritableTransactional
     public void invoke(final CompleteInfoCommand command) {
         final Member member = memberRepository.getById(command.memberId());
-        member.complete(command.name(), command.gender(), command.birth());
+        member.complete(command.nickname(), command.gender(), command.birth());
     }
 }

--- a/src/main/java/ac/dnd/bookkeeping/server/member/application/usecase/CompleteInfoUseCase.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/application/usecase/CompleteInfoUseCase.java
@@ -1,0 +1,20 @@
+package ac.dnd.bookkeeping.server.member.application.usecase;
+
+import ac.dnd.bookkeeping.server.global.annotation.UseCase;
+import ac.dnd.bookkeeping.server.global.annotation.WritableTransactional;
+import ac.dnd.bookkeeping.server.member.application.usecase.command.CompleteInfoCommand;
+import ac.dnd.bookkeeping.server.member.domain.model.Member;
+import ac.dnd.bookkeeping.server.member.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class CompleteInfoUseCase {
+    private final MemberRepository memberRepository;
+
+    @WritableTransactional
+    public void invoke(final CompleteInfoCommand command) {
+        final Member member = memberRepository.getById(command.memberId());
+        member.complete(command.name(), command.gender(), command.birth());
+    }
+}

--- a/src/main/java/ac/dnd/bookkeeping/server/member/application/usecase/ManageResourceUseCase.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/application/usecase/ManageResourceUseCase.java
@@ -4,6 +4,7 @@ import ac.dnd.bookkeeping.server.global.annotation.UseCase;
 import ac.dnd.bookkeeping.server.global.annotation.WritableTransactional;
 import ac.dnd.bookkeeping.server.member.application.usecase.command.CompleteInfoCommand;
 import ac.dnd.bookkeeping.server.member.domain.model.Member;
+import ac.dnd.bookkeeping.server.member.domain.model.Nickname;
 import ac.dnd.bookkeeping.server.member.domain.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -11,6 +12,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ManageResourceUseCase {
     private final MemberRepository memberRepository;
+
+    public boolean isUniqueNickname(final Nickname nickname) {
+        return !memberRepository.existsByNickname(nickname);
+    }
 
     @WritableTransactional
     public void completeInfo(final CompleteInfoCommand command) {

--- a/src/main/java/ac/dnd/bookkeeping/server/member/application/usecase/ManageResourceUseCase.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/application/usecase/ManageResourceUseCase.java
@@ -9,11 +9,11 @@ import lombok.RequiredArgsConstructor;
 
 @UseCase
 @RequiredArgsConstructor
-public class CompleteInfoUseCase {
+public class ManageResourceUseCase {
     private final MemberRepository memberRepository;
 
     @WritableTransactional
-    public void invoke(final CompleteInfoCommand command) {
+    public void completeInfo(final CompleteInfoCommand command) {
         final Member member = memberRepository.getById(command.memberId());
         member.complete(command.nickname(), command.gender(), command.birth());
     }

--- a/src/main/java/ac/dnd/bookkeeping/server/member/application/usecase/command/CompleteInfoCommand.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/application/usecase/command/CompleteInfoCommand.java
@@ -1,12 +1,13 @@
 package ac.dnd.bookkeeping.server.member.application.usecase.command;
 
 import ac.dnd.bookkeeping.server.member.domain.model.Member;
+import ac.dnd.bookkeeping.server.member.domain.model.Nickname;
 
 import java.time.LocalDate;
 
 public record CompleteInfoCommand(
         long memberId,
-        String name,
+        Nickname nickname,
         Member.Gender gender,
         LocalDate birth
 ) {

--- a/src/main/java/ac/dnd/bookkeeping/server/member/application/usecase/command/CompleteInfoCommand.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/application/usecase/command/CompleteInfoCommand.java
@@ -1,0 +1,13 @@
+package ac.dnd.bookkeeping.server.member.application.usecase.command;
+
+import ac.dnd.bookkeeping.server.member.domain.model.Member;
+
+import java.time.LocalDate;
+
+public record CompleteInfoCommand(
+        long memberId,
+        String name,
+        Member.Gender gender,
+        LocalDate birth
+) {
+}

--- a/src/main/java/ac/dnd/bookkeeping/server/member/domain/model/Email.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/domain/model/Email.java
@@ -17,7 +17,7 @@ import static lombok.AccessLevel.PROTECTED;
 public class Email {
     private static final Pattern pattern = Pattern.compile("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
 
-    @Column(name = "email", unique = true)
+    @Column(name = "email", nullable = false, unique = true)
     private String value;
 
     private Email(final String value) {

--- a/src/main/java/ac/dnd/bookkeeping/server/member/domain/model/Member.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/domain/model/Member.java
@@ -25,4 +25,8 @@ public class Member extends BaseEntity<Member> {
         this.platform = platform;
         this.name = name;
     }
+
+    public void syncEmail(final Email email) {
+        platform.syncEmail(email);
+    }
 }

--- a/src/main/java/ac/dnd/bookkeeping/server/member/domain/model/Member.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/domain/model/Member.java
@@ -1,6 +1,7 @@
 package ac.dnd.bookkeeping.server.member.domain.model;
 
 import ac.dnd.bookkeeping.server.global.base.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
@@ -15,11 +16,13 @@ import static lombok.AccessLevel.PROTECTED;
 @Table(name = "member")
 public class Member extends BaseEntity<Member> {
     @Embedded
-    private Email email;
+    private SocialPlatform platform;
 
-    // TODO 회원가입 + 로그인 플로우에서 추가적인 필드 정의
+    @Column(name = "name", nullable = false)
+    private String name;
 
-    public Member(final Email email) {
-        this.email = email;
+    public Member(final SocialPlatform platform, final String name) {
+        this.platform = platform;
+        this.name = name;
     }
 }

--- a/src/main/java/ac/dnd/bookkeeping/server/member/domain/model/Member.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/domain/model/Member.java
@@ -1,13 +1,21 @@
 package ac.dnd.bookkeeping.server.member.domain.model;
 
 import ac.dnd.bookkeeping.server.global.base.BaseEntity;
+import ac.dnd.bookkeeping.server.member.exception.MemberException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import static ac.dnd.bookkeeping.server.member.exception.MemberExceptionCode.INVALID_GENDER;
+import static jakarta.persistence.EnumType.STRING;
 import static lombok.AccessLevel.PROTECTED;
 
 @Getter
@@ -21,12 +29,43 @@ public class Member extends BaseEntity<Member> {
     @Column(name = "name", nullable = false)
     private String name;
 
-    public Member(final SocialPlatform platform, final String name) {
+    @Enumerated(STRING)
+    @Column(name = "gender", columnDefinition = "VARCHAR(20)")
+    private Gender gender;
+
+    @Column(name = "birth")
+    private LocalDate birth;
+
+    public Member(
+            final SocialPlatform platform,
+            final String name,
+            final Gender gender,
+            final LocalDate birth
+    ) {
         this.platform = platform;
         this.name = name;
+        this.gender = gender;
+        this.birth = birth;
     }
 
     public void syncEmail(final Email email) {
         this.platform = platform.syncEmail(email);
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum Gender {
+        MAIL("male"),
+        FEMAIL("female"),
+        ;
+
+        private final String value;
+
+        public static Gender from(final String value) {
+            return Arrays.stream(values())
+                    .filter(it -> it.value.equals(value))
+                    .findFirst()
+                    .orElseThrow(() -> new MemberException(INVALID_GENDER));
+        }
     }
 }

--- a/src/main/java/ac/dnd/bookkeeping/server/member/domain/model/Member.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/domain/model/Member.java
@@ -52,6 +52,12 @@ public class Member extends BaseEntity<Member> {
         this.platform = platform.syncEmail(email);
     }
 
+    public void complete(final String name, final Gender gender, final LocalDate birth) {
+        this.name = name;
+        this.gender = gender;
+        this.birth = birth;
+    }
+
     @Getter
     @RequiredArgsConstructor
     public enum Gender {

--- a/src/main/java/ac/dnd/bookkeeping/server/member/domain/model/Member.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/domain/model/Member.java
@@ -26,8 +26,11 @@ public class Member extends BaseEntity<Member> {
     @Embedded
     private SocialPlatform platform;
 
-    @Column(name = "name", nullable = false)
-    private String name;
+    @Column(name = "profile_image_url", nullable = false)
+    private String profileImageUrl;
+
+    @Embedded
+    private Nickname nickname;
 
     @Enumerated(STRING)
     @Column(name = "gender", columnDefinition = "VARCHAR(20)")
@@ -36,24 +39,30 @@ public class Member extends BaseEntity<Member> {
     @Column(name = "birth")
     private LocalDate birth;
 
-    public Member(
+    private Member(
             final SocialPlatform platform,
-            final String name,
+            final String profileImageUrl,
+            final Nickname nickname,
             final Gender gender,
             final LocalDate birth
     ) {
         this.platform = platform;
-        this.name = name;
+        this.profileImageUrl = profileImageUrl;
+        this.nickname = nickname;
         this.gender = gender;
         this.birth = birth;
+    }
+
+    public static Member create(final SocialPlatform platform, final String profileImageUrl) {
+        return new Member(platform, profileImageUrl, null, null, null);
     }
 
     public void syncEmail(final Email email) {
         this.platform = platform.syncEmail(email);
     }
 
-    public void complete(final String name, final Gender gender, final LocalDate birth) {
-        this.name = name;
+    public void complete(final Nickname nickname, final Gender gender, final LocalDate birth) {
+        this.nickname = nickname;
         this.gender = gender;
         this.birth = birth;
     }

--- a/src/main/java/ac/dnd/bookkeeping/server/member/domain/model/Member.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/domain/model/Member.java
@@ -27,6 +27,6 @@ public class Member extends BaseEntity<Member> {
     }
 
     public void syncEmail(final Email email) {
-        platform.syncEmail(email);
+        this.platform = platform.syncEmail(email);
     }
 }

--- a/src/main/java/ac/dnd/bookkeeping/server/member/domain/model/Nickname.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/domain/model/Nickname.java
@@ -1,0 +1,53 @@
+package ac.dnd.bookkeeping.server.member.domain.model;
+
+import ac.dnd.bookkeeping.server.member.exception.MemberException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.regex.Pattern;
+
+import static ac.dnd.bookkeeping.server.member.exception.MemberExceptionCode.INVALID_NICKNAME_PATTERN;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Embeddable
+public class Nickname {
+    /**
+     * 1. 한글 & 알파벳 대소문자 & 숫자 가능
+     * <br>
+     * 2. 공백 불가능
+     * <br>
+     * 3. 1자 이상 15자 이하
+     */
+    private static final Pattern pattern = Pattern.compile("^[a-zA-Z가-힣0-9]{1,15}$");
+
+    @Column(name = "nickname", unique = true)
+    private String value;
+
+    private Nickname(final String value) {
+        this.value = value;
+    }
+
+    public static Nickname from(final String value) {
+        validateNicknamePattern(value);
+        return new Nickname(value);
+    }
+
+    public Nickname update(final String value) {
+        validateNicknamePattern(value);
+        return new Nickname(value);
+    }
+
+    private static void validateNicknamePattern(final String value) {
+        if (isInvalidPattern(value)) {
+            throw new MemberException(INVALID_NICKNAME_PATTERN);
+        }
+    }
+
+    private static boolean isInvalidPattern(final String value) {
+        return !pattern.matcher(value).matches();
+    }
+}

--- a/src/main/java/ac/dnd/bookkeeping/server/member/domain/model/SocialPlatform.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/domain/model/SocialPlatform.java
@@ -1,0 +1,42 @@
+package ac.dnd.bookkeeping.server.member.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Enumerated;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static ac.dnd.bookkeeping.server.member.domain.model.SocialPlatform.Type.KAKAO;
+import static jakarta.persistence.EnumType.STRING;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Embeddable
+public class SocialPlatform {
+    @Enumerated(STRING)
+    @Column(name = "social_type", nullable = false, columnDefinition = "VARCHAR(30)")
+    private Type type;
+
+    @Column(name = "social_id", nullable = false, unique = true)
+    private String socialId;
+
+    @Embedded
+    private Email email;
+
+    private SocialPlatform(final Type type, final String socialId, final Email email) {
+        this.type = type;
+        this.socialId = socialId;
+        this.email = email;
+    }
+
+    // 카카오 외에 확장될 플랫폼 존재하면 그때 수정
+    public static SocialPlatform of(final String socialId, final Email email) {
+        return new SocialPlatform(KAKAO, socialId, email);
+    }
+
+    public enum Type {
+        KAKAO
+    }
+}

--- a/src/main/java/ac/dnd/bookkeeping/server/member/domain/model/SocialPlatform.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/domain/model/SocialPlatform.java
@@ -36,6 +36,10 @@ public class SocialPlatform {
         return new SocialPlatform(KAKAO, socialId, email);
     }
 
+    public void syncEmail(final Email email) {
+        this.email = email;
+    }
+
     public enum Type {
         KAKAO
     }

--- a/src/main/java/ac/dnd/bookkeeping/server/member/domain/model/SocialPlatform.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/domain/model/SocialPlatform.java
@@ -36,8 +36,8 @@ public class SocialPlatform {
         return new SocialPlatform(KAKAO, socialId, email);
     }
 
-    public void syncEmail(final Email email) {
-        this.email = email;
+    public SocialPlatform syncEmail(final Email email) {
+        return new SocialPlatform(type, socialId, email);
     }
 
     public enum Type {

--- a/src/main/java/ac/dnd/bookkeeping/server/member/domain/repository/MemberRepository.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/domain/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package ac.dnd.bookkeeping.server.member.domain.repository;
 
 import ac.dnd.bookkeeping.server.member.domain.model.Member;
+import ac.dnd.bookkeeping.server.member.domain.model.Nickname;
 import ac.dnd.bookkeeping.server.member.exception.MemberException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -15,4 +16,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     }
 
     Optional<Member> findByPlatformSocialId(final String socialId);
+
+    boolean existsByNickname(final Nickname nickname);
 }

--- a/src/main/java/ac/dnd/bookkeeping/server/member/domain/repository/MemberRepository.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/domain/repository/MemberRepository.java
@@ -4,6 +4,8 @@ import ac.dnd.bookkeeping.server.member.domain.model.Member;
 import ac.dnd.bookkeeping.server.member.exception.MemberException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 import static ac.dnd.bookkeeping.server.member.exception.MemberExceptionCode.MEMBER_NOT_FOUND;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -11,4 +13,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
         return findById(id)
                 .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
     }
+
+    Optional<Member> findByPlatformSocialId(final String socialId);
 }

--- a/src/main/java/ac/dnd/bookkeeping/server/member/exception/MemberExceptionCode.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/exception/MemberExceptionCode.java
@@ -13,6 +13,7 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 public enum MemberExceptionCode implements BaseExceptionCode {
     MEMBER_NOT_FOUND(NOT_FOUND, "MEMBER_001", "사용자 정보가 존재하지 않습니다."),
     INVALID_EMAIL_PATTERN(BAD_REQUEST, "MEMBER_002", "이메일 형식에 맞지 않습니다."),
+    INVALID_GENDER(BAD_REQUEST, "MEMBER_003", "잘못된 성별입니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/ac/dnd/bookkeeping/server/member/exception/MemberExceptionCode.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/exception/MemberExceptionCode.java
@@ -14,6 +14,8 @@ public enum MemberExceptionCode implements BaseExceptionCode {
     MEMBER_NOT_FOUND(NOT_FOUND, "MEMBER_001", "사용자 정보가 존재하지 않습니다."),
     INVALID_EMAIL_PATTERN(BAD_REQUEST, "MEMBER_002", "이메일 형식에 맞지 않습니다."),
     INVALID_GENDER(BAD_REQUEST, "MEMBER_003", "잘못된 성별입니다."),
+    INVALID_NICKNAME_PATTERN(BAD_REQUEST, "MEMBER_004", "닉네임 형식에 맞지 않습니다."),
+    INVALID_AGE_RANGE(BAD_REQUEST, "MEMBER_005", "잘못된 연령대입니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/ac/dnd/bookkeeping/server/member/presentation/ManageResourceApiController.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/presentation/ManageResourceApiController.java
@@ -1,0 +1,52 @@
+package ac.dnd.bookkeeping.server.member.presentation;
+
+import ac.dnd.bookkeeping.server.auth.domain.model.Authenticated;
+import ac.dnd.bookkeeping.server.global.annotation.Auth;
+import ac.dnd.bookkeeping.server.global.dto.ResponseWrapper;
+import ac.dnd.bookkeeping.server.member.application.usecase.ManageResourceUseCase;
+import ac.dnd.bookkeeping.server.member.application.usecase.command.CompleteInfoCommand;
+import ac.dnd.bookkeeping.server.member.presentation.dto.request.CheckNicknameRequest;
+import ac.dnd.bookkeeping.server.member.presentation.dto.request.CompleteInfoRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "사용자 리소스 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class ManageResourceApiController {
+    private final ManageResourceUseCase manageResourceUseCase;
+
+    @Operation(summary = "닉네임 중복 체크 Endpoint")
+    @GetMapping("/v1/check-nickname")
+    public ResponseEntity<ResponseWrapper<Boolean>> checkNickname(
+            @ModelAttribute @Valid final CheckNicknameRequest request
+    ) {
+        final boolean result = manageResourceUseCase.isUniqueNickname(request.toNickname());
+        return ResponseEntity.ok(ResponseWrapper.from(result));
+    }
+
+    @Operation(summary = "온보딩 사용자 추가 정보 기입 Endpoint")
+    @PatchMapping("/v1/members/me/complete")
+    public ResponseEntity<Void> complete(
+            @Auth final Authenticated authenticated,
+            @RequestBody @Valid final CompleteInfoRequest request
+    ) {
+        manageResourceUseCase.completeInfo(new CompleteInfoCommand(
+                authenticated.id(),
+                request.toNickname(),
+                request.toGender(),
+                request.birth()
+        ));
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/ac/dnd/bookkeeping/server/member/presentation/dto/request/CheckNicknameRequest.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/presentation/dto/request/CheckNicknameRequest.java
@@ -1,0 +1,13 @@
+package ac.dnd.bookkeeping.server.member.presentation.dto.request;
+
+import ac.dnd.bookkeeping.server.member.domain.model.Nickname;
+import jakarta.validation.constraints.NotBlank;
+
+public record CheckNicknameRequest(
+        @NotBlank(message = "중복 체크할 닉네임은 필수입니다.")
+        String nickname
+) {
+    public Nickname toNickname() {
+        return Nickname.from(nickname);
+    }
+}

--- a/src/main/java/ac/dnd/bookkeeping/server/member/presentation/dto/request/CompleteInfoRequest.java
+++ b/src/main/java/ac/dnd/bookkeeping/server/member/presentation/dto/request/CompleteInfoRequest.java
@@ -1,0 +1,27 @@
+package ac.dnd.bookkeeping.server.member.presentation.dto.request;
+
+import ac.dnd.bookkeeping.server.member.domain.model.Member;
+import ac.dnd.bookkeeping.server.member.domain.model.Nickname;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record CompleteInfoRequest(
+        @NotBlank(message = "닉네임은 필수입니다.")
+        String nickname,
+
+        @NotBlank(message = "성별은 필수입니다.")
+        String gender,
+
+        @NotNull(message = "생년월일은 필수입니다.")
+        LocalDate birth
+) {
+    public Nickname toNickname() {
+        return Nickname.from(nickname);
+    }
+
+    public Member.Gender toGender() {
+        return Member.Gender.from(gender);
+    }
+}

--- a/src/main/resources/db/migration/V1__create_member_table.sql
+++ b/src/main/resources/db/migration/V1__create_member_table.sql
@@ -5,6 +5,8 @@ CREATE TABLE IF NOT EXISTS member
     social_id        VARCHAR(100) NOT NULL UNIQUE,
     email            VARCHAR(200) NOT NULL UNIQUE,
     name             VARCHAR(100) NOT NULL,
+    gender           VARCHAR(20)  NULL,
+    birth            DATE         NULL,
     created_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     last_modified_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 

--- a/src/main/resources/db/migration/V1__create_member_table.sql
+++ b/src/main/resources/db/migration/V1__create_member_table.sql
@@ -1,8 +1,13 @@
 CREATE TABLE IF NOT EXISTS member
 (
     id               BIGINT AUTO_INCREMENT PRIMARY KEY,
-    email            VARCHAR(200) NULL UNIQUE,
+    social_type      VARCHAR(30)  NOT NULL,
+    social_id        VARCHAR(100) NOT NULL UNIQUE,
+    email            VARCHAR(200) NOT NULL UNIQUE,
+    name             VARCHAR(100) NOT NULL,
     created_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    last_modified_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    last_modified_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    UNIQUE (social_id, email)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4;

--- a/src/main/resources/db/migration/V1__create_member_table.sql
+++ b/src/main/resources/db/migration/V1__create_member_table.sql
@@ -1,14 +1,15 @@
 CREATE TABLE IF NOT EXISTS member
 (
-    id               BIGINT AUTO_INCREMENT PRIMARY KEY,
-    social_type      VARCHAR(30)  NOT NULL,
-    social_id        VARCHAR(100) NOT NULL UNIQUE,
-    email            VARCHAR(200) NOT NULL UNIQUE,
-    name             VARCHAR(100) NOT NULL,
-    gender           VARCHAR(20)  NULL,
-    birth            DATE         NULL,
-    created_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    last_modified_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    id                BIGINT AUTO_INCREMENT PRIMARY KEY,
+    social_type       VARCHAR(30)  NOT NULL,
+    social_id         VARCHAR(200) NOT NULL UNIQUE,
+    email             VARCHAR(200) NOT NULL UNIQUE,
+    profile_image_url VARCHAR(200) NOT NULL,
+    nickname          VARCHAR(30)  NULL UNIQUE,
+    gender            VARCHAR(20)  NULL,
+    birth             DATE         NULL,
+    created_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_modified_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 
     UNIQUE (social_id, email)
 ) ENGINE = InnoDB

--- a/src/test/java/ac/dnd/bookkeeping/server/auth/application/usecase/LoginUseCaseTest.java
+++ b/src/test/java/ac/dnd/bookkeeping/server/auth/application/usecase/LoginUseCaseTest.java
@@ -1,0 +1,84 @@
+package ac.dnd.bookkeeping.server.auth.application.usecase;
+
+import ac.dnd.bookkeeping.server.auth.application.usecase.command.LoginCommand;
+import ac.dnd.bookkeeping.server.auth.application.usecase.command.response.LoginResponse;
+import ac.dnd.bookkeeping.server.auth.domain.model.AuthToken;
+import ac.dnd.bookkeeping.server.auth.domain.service.TokenIssuer;
+import ac.dnd.bookkeeping.server.common.UnitTest;
+import ac.dnd.bookkeeping.server.member.domain.model.Member;
+import ac.dnd.bookkeeping.server.member.domain.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static ac.dnd.bookkeeping.server.common.fixture.MemberFixture.MEMBER_1;
+import static ac.dnd.bookkeeping.server.common.utils.TokenUtils.ACCESS_TOKEN;
+import static ac.dnd.bookkeeping.server.common.utils.TokenUtils.REFRESH_TOKEN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("Member -> LoginUseCase 테스트")
+class LoginUseCaseTest extends UnitTest {
+    private final MemberRepository memberRepository = mock(MemberRepository.class);
+    private final TokenIssuer tokenIssuer = mock(TokenIssuer.class);
+    private final LoginUseCase sut = new LoginUseCase(memberRepository, tokenIssuer);
+
+    private final Member member = MEMBER_1.toDomain().apply(1L);
+    private final LoginCommand command = new LoginCommand(member.getPlatform(), member.getName());
+
+    @Test
+    @DisplayName("처음 로그인하는 사용자는 회원가입 프로세스를 진행하고 로그인 처리를 한다")
+    void first() {
+        // given
+        given(memberRepository.findByPlatformSocialId(command.platform().getSocialId())).willReturn(Optional.empty());
+        given(memberRepository.save(any())).willReturn(member);
+
+        final AuthToken token = new AuthToken(ACCESS_TOKEN, REFRESH_TOKEN);
+        given(tokenIssuer.provideAuthorityToken(member.getId())).willReturn(token);
+
+        // when
+        final LoginResponse response = sut.invoke(command);
+
+        // then
+        assertAll(
+                () -> verify(memberRepository, times(1)).findByPlatformSocialId(command.platform().getSocialId()),
+                () -> verify(memberRepository, times(1)).save(any()),
+                () -> verify(tokenIssuer, times(1)).provideAuthorityToken(member.getId()),
+                () -> assertThat(response.isNew()).isTrue(),
+                () -> assertThat(response.info().name()).isEqualTo(member.getName()),
+                () -> assertThat(response.token().accessToken()).isEqualTo(token.accessToken()),
+                () -> assertThat(response.token().refreshToken()).isEqualTo(token.refreshToken())
+        );
+    }
+
+    @Test
+    @DisplayName("이미 가입된 사용자는 추가적인 회원가입 없이 로그인 처리를 진행한다")
+    void alreadyExists() {
+        // given
+        given(memberRepository.findByPlatformSocialId(command.platform().getSocialId())).willReturn(Optional.of(member));
+
+        final AuthToken token = new AuthToken(ACCESS_TOKEN, REFRESH_TOKEN);
+        given(tokenIssuer.provideAuthorityToken(member.getId())).willReturn(token);
+
+        // when
+        final LoginResponse response = sut.invoke(command);
+
+        // then
+        assertAll(
+                () -> verify(memberRepository, times(1)).findByPlatformSocialId(command.platform().getSocialId()),
+                () -> verify(memberRepository, times(0)).save(any()),
+                () -> verify(tokenIssuer, times(1)).provideAuthorityToken(member.getId()),
+                () -> assertThat(response.isNew()).isFalse(),
+                () -> assertThat(response.info().name()).isEqualTo(member.getName()),
+                () -> assertThat(response.token().accessToken()).isEqualTo(token.accessToken()),
+                () -> assertThat(response.token().refreshToken()).isEqualTo(token.refreshToken()),
+                () -> assertThat(member.getPlatform().getEmail().getValue()).isEqualTo(command.platform().getEmail().getValue())
+        );
+    }
+}

--- a/src/test/java/ac/dnd/bookkeeping/server/auth/application/usecase/LoginUseCaseTest.java
+++ b/src/test/java/ac/dnd/bookkeeping/server/auth/application/usecase/LoginUseCaseTest.java
@@ -35,9 +35,7 @@ class LoginUseCaseTest extends UnitTest {
         // given
         final LoginCommand command = new LoginCommand(
                 MEMBER_1.getPlatform(),
-                MEMBER_1.getName(),
-                null,
-                null
+                MEMBER_1.getProfileImageUrl()
         );
         given(memberRepository.findByPlatformSocialId(command.platform().getSocialId())).willReturn(Optional.empty());
 
@@ -57,11 +55,8 @@ class LoginUseCaseTest extends UnitTest {
                 () -> verify(tokenIssuer, times(1)).provideAuthorityToken(member.getId()),
 
                 () -> assertThat(response.isNew()).isTrue(),
-                () -> assertThat(response.info().name()).isEqualTo(member.getName()),
-                () -> assertThat(response.info().gender()).isNull(),
-                () -> assertThat(response.info().birth()).isNull(),
-                () -> assertThat(response.token().accessToken()).isEqualTo(token.accessToken()),
-                () -> assertThat(response.token().refreshToken()).isEqualTo(token.refreshToken())
+                () -> assertThat(response.accessToken()).isEqualTo(token.accessToken()),
+                () -> assertThat(response.refreshToken()).isEqualTo(token.refreshToken())
         );
     }
 
@@ -71,9 +66,7 @@ class LoginUseCaseTest extends UnitTest {
         // given
         final LoginCommand command = new LoginCommand(
                 MEMBER_1.getPlatform(),
-                MEMBER_1.getName(),
-                MEMBER_1.getGender(),
-                MEMBER_1.getBirth()
+                MEMBER_1.getProfileImageUrl()
         );
         given(memberRepository.findByPlatformSocialId(command.platform().getSocialId())).willReturn(Optional.empty());
 
@@ -93,11 +86,8 @@ class LoginUseCaseTest extends UnitTest {
                 () -> verify(tokenIssuer, times(1)).provideAuthorityToken(member.getId()),
 
                 () -> assertThat(response.isNew()).isTrue(),
-                () -> assertThat(response.info().name()).isEqualTo(member.getName()),
-                () -> assertThat(response.info().gender()).isEqualTo(member.getGender().getValue()),
-                () -> assertThat(response.info().birth()).isEqualTo(member.getBirth()),
-                () -> assertThat(response.token().accessToken()).isEqualTo(token.accessToken()),
-                () -> assertThat(response.token().refreshToken()).isEqualTo(token.refreshToken())
+                () -> assertThat(response.accessToken()).isEqualTo(token.accessToken()),
+                () -> assertThat(response.refreshToken()).isEqualTo(token.refreshToken())
         );
     }
 
@@ -107,9 +97,7 @@ class LoginUseCaseTest extends UnitTest {
         // given
         final LoginCommand command = new LoginCommand(
                 MEMBER_1.getPlatform(),
-                MEMBER_1.getName(),
-                MEMBER_1.getGender(),
-                MEMBER_1.getBirth()
+                MEMBER_1.getProfileImageUrl()
         );
 
         final Member member = command.toDomain().apply(1L);
@@ -130,11 +118,8 @@ class LoginUseCaseTest extends UnitTest {
                 () -> assertThat(member.getPlatform().getEmail().getValue()).isEqualTo(command.platform().getEmail().getValue()),
 
                 () -> assertThat(response.isNew()).isFalse(),
-                () -> assertThat(response.info().name()).isEqualTo(member.getName()),
-                () -> assertThat(response.info().gender()).isEqualTo(member.getGender().getValue()),
-                () -> assertThat(response.info().birth()).isEqualTo(member.getBirth()),
-                () -> assertThat(response.token().accessToken()).isEqualTo(token.accessToken()),
-                () -> assertThat(response.token().refreshToken()).isEqualTo(token.refreshToken())
+                () -> assertThat(response.accessToken()).isEqualTo(token.accessToken()),
+                () -> assertThat(response.refreshToken()).isEqualTo(token.refreshToken())
         );
     }
 }

--- a/src/test/java/ac/dnd/bookkeeping/server/auth/presentation/AuthApiControllerTest.java
+++ b/src/test/java/ac/dnd/bookkeeping/server/auth/presentation/AuthApiControllerTest.java
@@ -1,0 +1,105 @@
+package ac.dnd.bookkeeping.server.auth.presentation;
+
+import ac.dnd.bookkeeping.server.auth.application.usecase.LoginUseCase;
+import ac.dnd.bookkeeping.server.auth.application.usecase.LogoutUseCase;
+import ac.dnd.bookkeeping.server.auth.application.usecase.command.response.LoginResponse;
+import ac.dnd.bookkeeping.server.auth.domain.model.AuthToken;
+import ac.dnd.bookkeeping.server.auth.presentation.dto.request.LoginRequest;
+import ac.dnd.bookkeeping.server.common.ControllerTest;
+import ac.dnd.bookkeeping.server.member.domain.model.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static ac.dnd.bookkeeping.server.common.fixture.MemberFixture.MEMBER_1;
+import static ac.dnd.bookkeeping.server.common.utils.RestDocsSpecificationUtils.SnippetFactory.body;
+import static ac.dnd.bookkeeping.server.common.utils.RestDocsSpecificationUtils.createHttpSpecSnippets;
+import static ac.dnd.bookkeeping.server.common.utils.RestDocsSpecificationUtils.successDocs;
+import static ac.dnd.bookkeeping.server.common.utils.RestDocsSpecificationUtils.successDocsWithAccessToken;
+import static ac.dnd.bookkeeping.server.common.utils.TokenUtils.ACCESS_TOKEN;
+import static ac.dnd.bookkeeping.server.common.utils.TokenUtils.REFRESH_TOKEN;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Member -> AuthApiController 테스트")
+class AuthApiControllerTest extends ControllerTest {
+    @Autowired
+    private LoginUseCase loginUseCase;
+
+    @Autowired
+    private LogoutUseCase logoutUseCase;
+
+    @Nested
+    @DisplayName("로그인 API [POST /api/v1/auth/login]")
+    class Login {
+        private static final String BASE_URL = "/api/v1/auth/login";
+        private final LoginRequest request = new LoginRequest(
+                MEMBER_1.getPlatform().getSocialId(),
+                MEMBER_1.getPlatform().getEmail().getValue(),
+                MEMBER_1.getName()
+        );
+
+
+        @Test
+        @DisplayName("로그인을 진행한다")
+        void success() {
+            // given
+            given(loginUseCase.invoke(any())).willReturn(new LoginResponse(
+                    true,
+                    new LoginResponse.MemberInfo(
+                            "사용자 이름..."
+                    ),
+                    new AuthToken(ACCESS_TOKEN, REFRESH_TOKEN)
+            ));
+
+            // when - then
+            successfulExecute(
+                    postRequest(BASE_URL, request),
+                    status().isOk(),
+                    successDocs("AuthApi/Login", createHttpSpecSnippets(
+                            requestFields(
+                                    body("socialId", "소셜 플랫폼 ID", true),
+                                    body("email", "소셜 플랫폼 이메일", true),
+                                    body("name", "소셜 플랫폼 사용자 이름", true)
+                            ),
+                            responseFields(
+                                    body("isNew", "새로운 사용자인지 여부"),
+                                    body("info.name", "사용자 이름"),
+                                    body("token.accessToken", "Access Token"),
+                                    body("token.refreshToken", "Refresh Token")
+                            )
+                    ))
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("로그아웃 API [POST /api/v1/auth/logout]")
+    class Logout {
+        private static final String BASE_URL = "/api/v1/auth/logout";
+        private final Member member = MEMBER_1.toDomain().apply(1L);
+
+
+        @Test
+        @DisplayName("로그아웃을 진행한다")
+        void success() {
+            // given
+            applyToken(true, member.getId());
+            doNothing()
+                    .when(logoutUseCase)
+                    .invoke(any());
+
+            // when - then
+            successfulExecute(
+                    postRequestWithAccessToken(BASE_URL),
+                    status().isNoContent(),
+                    successDocsWithAccessToken("AuthApi/Logout")
+            );
+        }
+    }
+}

--- a/src/test/java/ac/dnd/bookkeeping/server/auth/presentation/AuthApiControllerTest.java
+++ b/src/test/java/ac/dnd/bookkeeping/server/auth/presentation/AuthApiControllerTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.LocalDate;
+
 import static ac.dnd.bookkeeping.server.common.fixture.MemberFixture.MEMBER_1;
 import static ac.dnd.bookkeeping.server.common.utils.RestDocsSpecificationUtils.SnippetFactory.body;
 import static ac.dnd.bookkeeping.server.common.utils.RestDocsSpecificationUtils.createHttpSpecSnippets;
@@ -41,9 +43,10 @@ class AuthApiControllerTest extends ControllerTest {
         private final LoginRequest request = new LoginRequest(
                 MEMBER_1.getPlatform().getSocialId(),
                 MEMBER_1.getPlatform().getEmail().getValue(),
-                MEMBER_1.getName()
+                MEMBER_1.getName(),
+                MEMBER_1.getGender().getValue(),
+                MEMBER_1.getBirth()
         );
-
 
         @Test
         @DisplayName("로그인을 진행한다")
@@ -52,7 +55,9 @@ class AuthApiControllerTest extends ControllerTest {
             given(loginUseCase.invoke(any())).willReturn(new LoginResponse(
                     true,
                     new LoginResponse.MemberInfo(
-                            "사용자 이름..."
+                            "사용자 이름...",
+                            "male",
+                            LocalDate.of(2000, 1, 1)
                     ),
                     new AuthToken(ACCESS_TOKEN, REFRESH_TOKEN)
             ));
@@ -65,11 +70,15 @@ class AuthApiControllerTest extends ControllerTest {
                             requestFields(
                                     body("socialId", "소셜 플랫폼 ID", true),
                                     body("email", "소셜 플랫폼 이메일", true),
-                                    body("name", "소셜 플랫폼 사용자 이름", true)
+                                    body("name", "소셜 플랫폼 사용자 이름", true),
+                                    body("gender", "소셜 플랫폼 사용자 성별", false),
+                                    body("birth", "사용자 생년월일", "가공해서 LocalDate 형식으로 전달", false)
                             ),
                             responseFields(
                                     body("isNew", "새로운 사용자인지 여부"),
                                     body("info.name", "사용자 이름"),
+                                    body("info.gender", "사용자 성별", "Nullable"),
+                                    body("info.birth", "사용자 생년월일", "Nullable"),
                                     body("token.accessToken", "Access Token"),
                                     body("token.refreshToken", "Refresh Token")
                             )

--- a/src/test/java/ac/dnd/bookkeeping/server/auth/presentation/AuthApiControllerTest.java
+++ b/src/test/java/ac/dnd/bookkeeping/server/auth/presentation/AuthApiControllerTest.java
@@ -3,7 +3,6 @@ package ac.dnd.bookkeeping.server.auth.presentation;
 import ac.dnd.bookkeeping.server.auth.application.usecase.LoginUseCase;
 import ac.dnd.bookkeeping.server.auth.application.usecase.LogoutUseCase;
 import ac.dnd.bookkeeping.server.auth.application.usecase.command.response.LoginResponse;
-import ac.dnd.bookkeeping.server.auth.domain.model.AuthToken;
 import ac.dnd.bookkeeping.server.auth.presentation.dto.request.LoginRequest;
 import ac.dnd.bookkeeping.server.common.ControllerTest;
 import ac.dnd.bookkeeping.server.member.domain.model.Member;
@@ -11,8 +10,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.time.LocalDate;
 
 import static ac.dnd.bookkeeping.server.common.fixture.MemberFixture.MEMBER_1;
 import static ac.dnd.bookkeeping.server.common.utils.RestDocsSpecificationUtils.SnippetFactory.body;
@@ -43,24 +40,14 @@ class AuthApiControllerTest extends ControllerTest {
         private final LoginRequest request = new LoginRequest(
                 MEMBER_1.getPlatform().getSocialId(),
                 MEMBER_1.getPlatform().getEmail().getValue(),
-                MEMBER_1.getName(),
-                MEMBER_1.getGender().getValue(),
-                MEMBER_1.getBirth()
+                MEMBER_1.getProfileImageUrl()
         );
 
         @Test
         @DisplayName("로그인을 진행한다")
         void success() {
             // given
-            given(loginUseCase.invoke(any())).willReturn(new LoginResponse(
-                    true,
-                    new LoginResponse.MemberInfo(
-                            "사용자 이름...",
-                            "male",
-                            LocalDate.of(2000, 1, 1)
-                    ),
-                    new AuthToken(ACCESS_TOKEN, REFRESH_TOKEN)
-            ));
+            given(loginUseCase.invoke(any())).willReturn(new LoginResponse(true, ACCESS_TOKEN, REFRESH_TOKEN));
 
             // when - then
             successfulExecute(
@@ -70,17 +57,12 @@ class AuthApiControllerTest extends ControllerTest {
                             requestFields(
                                     body("socialId", "소셜 플랫폼 ID", true),
                                     body("email", "소셜 플랫폼 이메일", true),
-                                    body("name", "소셜 플랫폼 사용자 이름", true),
-                                    body("gender", "소셜 플랫폼 사용자 성별", false),
-                                    body("birth", "사용자 생년월일", "가공해서 LocalDate 형식으로 전달", false)
+                                    body("profileImageUrl", "소셜 플랫폼 사용자 이미지 URL", true)
                             ),
                             responseFields(
                                     body("isNew", "새로운 사용자인지 여부"),
-                                    body("info.name", "사용자 이름"),
-                                    body("info.gender", "사용자 성별", "Nullable"),
-                                    body("info.birth", "사용자 생년월일", "Nullable"),
-                                    body("token.accessToken", "Access Token"),
-                                    body("token.refreshToken", "Refresh Token")
+                                    body("accessToken", "Access Token"),
+                                    body("refreshToken", "Refresh Token")
                             )
                     ))
             );

--- a/src/test/java/ac/dnd/bookkeeping/server/auth/presentation/AuthApiControllerTest.java
+++ b/src/test/java/ac/dnd/bookkeeping/server/auth/presentation/AuthApiControllerTest.java
@@ -25,7 +25,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@DisplayName("Member -> AuthApiController 테스트")
+@DisplayName("Auth -> AuthApiController 테스트")
 class AuthApiControllerTest extends ControllerTest {
     @Autowired
     private LoginUseCase loginUseCase;

--- a/src/test/java/ac/dnd/bookkeeping/server/auth/presentation/TokenReissueApiControllerTest.java
+++ b/src/test/java/ac/dnd/bookkeeping/server/auth/presentation/TokenReissueApiControllerTest.java
@@ -30,9 +30,9 @@ class TokenReissueApiControllerTest extends ControllerTest {
     private final Member member = MEMBER_1.toDomain().apply(1L);
 
     @Nested
-    @DisplayName("토큰 재발급 API [POST /api/token/reissue]")
+    @DisplayName("토큰 재발급 API [POST /api/v1/token/reissue]")
     class ReissueToken {
-        private static final String BASE_URL = "/api/token/reissue";
+        private static final String BASE_URL = "/api/v1/token/reissue";
 
         @Test
         @DisplayName("유효하지 않은 RefreshToken으로 인해 토큰 재발급에 실패한다")

--- a/src/test/java/ac/dnd/bookkeeping/server/common/fixture/MemberFixture.java
+++ b/src/test/java/ac/dnd/bookkeeping/server/common/fixture/MemberFixture.java
@@ -6,25 +6,59 @@ import ac.dnd.bookkeeping.server.member.domain.model.SocialPlatform;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDate;
+
 @Getter
 @RequiredArgsConstructor
 public enum MemberFixture {
-    MEMBER_1(SocialPlatform.of("ID-member1", Email.from("member1@kakao.com")), "사용자1"),
-    MEMBER_2(SocialPlatform.of("ID-member2", Email.from("member2@kakao.com")), "사용자2"),
-    MEMBER_3(SocialPlatform.of("ID-member3", Email.from("member3@kakao.com")), "사용자3"),
-    MEMBER_4(SocialPlatform.of("ID-member4", Email.from("member4@kakao.com")), "사용자4"),
-    MEMBER_5(SocialPlatform.of("ID-member5", Email.from("member5@kakao.com")), "사용자5"),
-    MEMBER_6(SocialPlatform.of("ID-member6", Email.from("member6@kakao.com")), "사용자6"),
-    MEMBER_7(SocialPlatform.of("ID-member7", Email.from("member7@kakao.com")), "사용자7"),
-    MEMBER_8(SocialPlatform.of("ID-member8", Email.from("member8@kakao.com")), "사용자8"),
-    MEMBER_9(SocialPlatform.of("ID-member9", Email.from("member9@kakao.com")), "사용자9"),
-    MEMBER_10(SocialPlatform.of("ID-member10", Email.from("member10@kakao.com")), "사용자10"),
+    MEMBER_1(
+            SocialPlatform.of("ID-member1", Email.from("member1@kakao.com")), "사용자1",
+            Member.Gender.MAIL, LocalDate.of(2000, 1, 1)
+    ),
+    MEMBER_2(
+            SocialPlatform.of("ID-member2", Email.from("member2@kakao.com")), "사용자2",
+            Member.Gender.FEMAIL, LocalDate.of(2000, 1, 2)
+    ),
+    MEMBER_3(
+            SocialPlatform.of("ID-member3", Email.from("member3@kakao.com")), "사용자3",
+            Member.Gender.MAIL, LocalDate.of(2000, 1, 3)
+    ),
+    MEMBER_4(
+            SocialPlatform.of("ID-member4", Email.from("member4@kakao.com")), "사용자4",
+            Member.Gender.FEMAIL, LocalDate.of(2000, 1, 4)
+    ),
+    MEMBER_5(
+            SocialPlatform.of("ID-member5", Email.from("member5@kakao.com")), "사용자5",
+            Member.Gender.MAIL, LocalDate.of(2000, 1, 5)
+    ),
+    MEMBER_6(
+            SocialPlatform.of("ID-member6", Email.from("member6@kakao.com")), "사용자6",
+            Member.Gender.FEMAIL, LocalDate.of(2000, 1, 6)
+    ),
+    MEMBER_7(
+            SocialPlatform.of("ID-member7", Email.from("member7@kakao.com")), "사용자7",
+            Member.Gender.MAIL, LocalDate.of(2000, 1, 7)
+    ),
+    MEMBER_8(
+            SocialPlatform.of("ID-member8", Email.from("member8@kakao.com")), "사용자8",
+            Member.Gender.FEMAIL, LocalDate.of(2000, 1, 8)
+    ),
+    MEMBER_9(
+            SocialPlatform.of("ID-member9", Email.from("member9@kakao.com")), "사용자9",
+            Member.Gender.MAIL, LocalDate.of(2000, 1, 9)
+    ),
+    MEMBER_10(
+            SocialPlatform.of("ID-member10", Email.from("member10@kakao.com")), "사용자10",
+            Member.Gender.FEMAIL, LocalDate.of(2000, 1, 10)
+    ),
     ;
 
     private final SocialPlatform platform;
     private final String name;
+    private final Member.Gender gender;
+    private final LocalDate birth;
 
     public Member toDomain() {
-        return new Member(platform, name);
+        return new Member(platform, name, gender, birth);
     }
 }

--- a/src/test/java/ac/dnd/bookkeeping/server/common/fixture/MemberFixture.java
+++ b/src/test/java/ac/dnd/bookkeeping/server/common/fixture/MemberFixture.java
@@ -2,6 +2,7 @@ package ac.dnd.bookkeeping.server.common.fixture;
 
 import ac.dnd.bookkeeping.server.member.domain.model.Email;
 import ac.dnd.bookkeeping.server.member.domain.model.Member;
+import ac.dnd.bookkeeping.server.member.domain.model.Nickname;
 import ac.dnd.bookkeeping.server.member.domain.model.SocialPlatform;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -12,53 +13,56 @@ import java.time.LocalDate;
 @RequiredArgsConstructor
 public enum MemberFixture {
     MEMBER_1(
-            SocialPlatform.of("ID-member1", Email.from("member1@kakao.com")), "사용자1",
-            Member.Gender.MAIL, LocalDate.of(2000, 1, 1)
+            SocialPlatform.of("ID-member1", Email.from("member1@kakao.com")), "https://member-1-url",
+            Nickname.from("사용자1"), Member.Gender.MAIL, LocalDate.of(2000, 1, 1)
     ),
     MEMBER_2(
-            SocialPlatform.of("ID-member2", Email.from("member2@kakao.com")), "사용자2",
-            Member.Gender.FEMAIL, LocalDate.of(2000, 1, 2)
+            SocialPlatform.of("ID-member2", Email.from("member2@kakao.com")), "https://member-2-url",
+            Nickname.from("사용자2"), Member.Gender.FEMAIL, LocalDate.of(2000, 1, 2)
     ),
     MEMBER_3(
-            SocialPlatform.of("ID-member3", Email.from("member3@kakao.com")), "사용자3",
-            Member.Gender.MAIL, LocalDate.of(2000, 1, 3)
+            SocialPlatform.of("ID-member3", Email.from("member3@kakao.com")), "https://member-3-url",
+            Nickname.from("사용자3"), Member.Gender.MAIL, LocalDate.of(2000, 1, 3)
     ),
     MEMBER_4(
-            SocialPlatform.of("ID-member4", Email.from("member4@kakao.com")), "사용자4",
-            Member.Gender.FEMAIL, LocalDate.of(2000, 1, 4)
+            SocialPlatform.of("ID-member4", Email.from("member4@kakao.com")), "https://member-4-url",
+            Nickname.from("사용자4"), Member.Gender.FEMAIL, LocalDate.of(2000, 1, 4)
     ),
     MEMBER_5(
-            SocialPlatform.of("ID-member5", Email.from("member5@kakao.com")), "사용자5",
-            Member.Gender.MAIL, LocalDate.of(2000, 1, 5)
+            SocialPlatform.of("ID-member5", Email.from("member5@kakao.com")), "https://member-5-url",
+            Nickname.from("사용자5"), Member.Gender.MAIL, LocalDate.of(2000, 1, 5)
     ),
     MEMBER_6(
-            SocialPlatform.of("ID-member6", Email.from("member6@kakao.com")), "사용자6",
-            Member.Gender.FEMAIL, LocalDate.of(2000, 1, 6)
+            SocialPlatform.of("ID-member6", Email.from("member6@kakao.com")), "https://member-6-url",
+            Nickname.from("사용자6"), Member.Gender.FEMAIL, LocalDate.of(2000, 1, 6)
     ),
     MEMBER_7(
-            SocialPlatform.of("ID-member7", Email.from("member7@kakao.com")), "사용자7",
-            Member.Gender.MAIL, LocalDate.of(2000, 1, 7)
+            SocialPlatform.of("ID-member7", Email.from("member7@kakao.com")), "https://member-7-url",
+            Nickname.from("사용자7"), Member.Gender.MAIL, LocalDate.of(2000, 1, 7)
     ),
     MEMBER_8(
-            SocialPlatform.of("ID-member8", Email.from("member8@kakao.com")), "사용자8",
-            Member.Gender.FEMAIL, LocalDate.of(2000, 1, 8)
+            SocialPlatform.of("ID-member8", Email.from("member8@kakao.com")), "https://member-8-url",
+            Nickname.from("사용자8"), Member.Gender.FEMAIL, LocalDate.of(2000, 1, 8)
     ),
     MEMBER_9(
-            SocialPlatform.of("ID-member9", Email.from("member9@kakao.com")), "사용자9",
-            Member.Gender.MAIL, LocalDate.of(2000, 1, 9)
+            SocialPlatform.of("ID-member9", Email.from("member9@kakao.com")), "https://member-9-url",
+            Nickname.from("사용자9"), Member.Gender.MAIL, LocalDate.of(2000, 1, 9)
     ),
     MEMBER_10(
-            SocialPlatform.of("ID-member10", Email.from("member10@kakao.com")), "사용자10",
-            Member.Gender.FEMAIL, LocalDate.of(2000, 1, 10)
+            SocialPlatform.of("ID-member10", Email.from("member10@kakao.com")), "https://member-10-url",
+            Nickname.from("사용자10"), Member.Gender.FEMAIL, LocalDate.of(2000, 1, 10)
     ),
     ;
 
     private final SocialPlatform platform;
-    private final String name;
+    private final String profileImageUrl;
+    private final Nickname nickname;
     private final Member.Gender gender;
     private final LocalDate birth;
 
     public Member toDomain() {
-        return new Member(platform, name, gender, birth);
+        final Member member = Member.create(platform, profileImageUrl);
+        member.complete(nickname, gender, birth);
+        return member;
     }
 }

--- a/src/test/java/ac/dnd/bookkeeping/server/common/fixture/MemberFixture.java
+++ b/src/test/java/ac/dnd/bookkeeping/server/common/fixture/MemberFixture.java
@@ -2,27 +2,29 @@ package ac.dnd.bookkeeping.server.common.fixture;
 
 import ac.dnd.bookkeeping.server.member.domain.model.Email;
 import ac.dnd.bookkeeping.server.member.domain.model.Member;
+import ac.dnd.bookkeeping.server.member.domain.model.SocialPlatform;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public enum MemberFixture {
-    MEMBER_1(Email.from("member1@kakao.com")),
-    MEMBER_2(Email.from("member2@kakao.com")),
-    MEMBER_3(Email.from("member3@kakao.com")),
-    MEMBER_4(Email.from("member4@kakao.com")),
-    MEMBER_5(Email.from("member5@kakao.com")),
-    MEMBER_6(Email.from("member6@kakao.com")),
-    MEMBER_7(Email.from("member7@kakao.com")),
-    MEMBER_8(Email.from("member8@kakao.com")),
-    MEMBER_9(Email.from("member9@kakao.com")),
-    MEMBER_10(Email.from("member10@kakao.com")),
+    MEMBER_1(SocialPlatform.of("ID-member1", Email.from("member1@kakao.com")), "사용자1"),
+    MEMBER_2(SocialPlatform.of("ID-member2", Email.from("member2@kakao.com")), "사용자2"),
+    MEMBER_3(SocialPlatform.of("ID-member3", Email.from("member3@kakao.com")), "사용자3"),
+    MEMBER_4(SocialPlatform.of("ID-member4", Email.from("member4@kakao.com")), "사용자4"),
+    MEMBER_5(SocialPlatform.of("ID-member5", Email.from("member5@kakao.com")), "사용자5"),
+    MEMBER_6(SocialPlatform.of("ID-member6", Email.from("member6@kakao.com")), "사용자6"),
+    MEMBER_7(SocialPlatform.of("ID-member7", Email.from("member7@kakao.com")), "사용자7"),
+    MEMBER_8(SocialPlatform.of("ID-member8", Email.from("member8@kakao.com")), "사용자8"),
+    MEMBER_9(SocialPlatform.of("ID-member9", Email.from("member9@kakao.com")), "사용자9"),
+    MEMBER_10(SocialPlatform.of("ID-member10", Email.from("member10@kakao.com")), "사용자10"),
     ;
 
-    private final Email email;
+    private final SocialPlatform platform;
+    private final String name;
 
     public Member toDomain() {
-        return new Member(email);
+        return new Member(platform, name);
     }
 }

--- a/src/test/java/ac/dnd/bookkeeping/server/common/utils/RestDocsSpecificationUtils.java
+++ b/src/test/java/ac/dnd/bookkeeping/server/common/utils/RestDocsSpecificationUtils.java
@@ -53,7 +53,7 @@ public class RestDocsSpecificationUtils {
                 identifier,
                 getDocumentRequest(),
                 getDocumentResponse(),
-                Stream.concat(Arrays.stream(new Snippet[]{getCookieWithRefreshToken()}), Arrays.stream(snippets)).toArray(Snippet[]::new)
+                Stream.concat(Arrays.stream(new Snippet[]{getHeaderWithRefreshToken()}), Arrays.stream(snippets)).toArray(Snippet[]::new)
         );
     }
 
@@ -84,7 +84,7 @@ public class RestDocsSpecificationUtils {
                 getDocumentRequest(),
                 getDocumentResponse(),
                 Stream.concat(
-                        Arrays.stream(new Snippet[]{getCookieWithRefreshToken(), getExceptionResponseFields()}),
+                        Arrays.stream(new Snippet[]{getHeaderWithRefreshToken(), getExceptionResponseFields()}),
                         Arrays.stream(snippets)
                 ).toArray(Snippet[]::new)
         );
@@ -104,7 +104,7 @@ public class RestDocsSpecificationUtils {
         );
     }
 
-    private static Snippet getCookieWithRefreshToken() {
+    private static Snippet getHeaderWithRefreshToken() {
         return requestHeaders(
                 header(REFRESH_TOKEN_HEADER, "Refresh Token", true)
         );

--- a/src/test/java/ac/dnd/bookkeeping/server/member/application/usecase/CompleteInfoUseCaseTest.java
+++ b/src/test/java/ac/dnd/bookkeeping/server/member/application/usecase/CompleteInfoUseCaseTest.java
@@ -20,14 +20,14 @@ class CompleteInfoUseCaseTest extends UnitTest {
     private final CompleteInfoUseCase sut = new CompleteInfoUseCase(memberRepository);
 
     @Test
-    @DisplayName("온보딩 과정에서 사용자 추가 정보를 기입한다")
+    @DisplayName("온보딩 과정에서 사용자 추가 정보(닉네임, 성별, 생년월일)를 기입한다")
     void success() {
         // given
-        final Member member = new Member(MEMBER_1.getPlatform(), MEMBER_1.getName(), null, null).apply(1L);
+        final Member member = Member.create(MEMBER_1.getPlatform(), MEMBER_1.getProfileImageUrl()).apply(1L);
 
         final CompleteInfoCommand command = new CompleteInfoCommand(
                 member.getId(),
-                MEMBER_2.getName(),
+                MEMBER_2.getNickname(),
                 MEMBER_1.getGender(),
                 MEMBER_1.getBirth()
         );
@@ -38,7 +38,10 @@ class CompleteInfoUseCaseTest extends UnitTest {
 
         // then
         assertAll(
-                () -> assertThat(member.getName()).isEqualTo(command.name()),
+                () -> assertThat(member.getPlatform().getSocialId()).isEqualTo(MEMBER_1.getPlatform().getSocialId()),
+                () -> assertThat(member.getPlatform().getEmail().getValue()).isEqualTo(MEMBER_1.getPlatform().getEmail().getValue()),
+                () -> assertThat(member.getProfileImageUrl()).isEqualTo(MEMBER_1.getProfileImageUrl()),
+                () -> assertThat(member.getNickname().getValue()).isEqualTo(command.nickname().getValue()),
                 () -> assertThat(member.getGender()).isEqualTo(command.gender()),
                 () -> assertThat(member.getBirth()).isEqualTo(command.birth())
         );

--- a/src/test/java/ac/dnd/bookkeeping/server/member/application/usecase/CompleteInfoUseCaseTest.java
+++ b/src/test/java/ac/dnd/bookkeeping/server/member/application/usecase/CompleteInfoUseCaseTest.java
@@ -1,0 +1,46 @@
+package ac.dnd.bookkeeping.server.member.application.usecase;
+
+import ac.dnd.bookkeeping.server.common.UnitTest;
+import ac.dnd.bookkeeping.server.member.application.usecase.command.CompleteInfoCommand;
+import ac.dnd.bookkeeping.server.member.domain.model.Member;
+import ac.dnd.bookkeeping.server.member.domain.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static ac.dnd.bookkeeping.server.common.fixture.MemberFixture.MEMBER_1;
+import static ac.dnd.bookkeeping.server.common.fixture.MemberFixture.MEMBER_2;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("Member -> CompleteInfoUseCase 테스트")
+class CompleteInfoUseCaseTest extends UnitTest {
+    private final MemberRepository memberRepository = mock(MemberRepository.class);
+    private final CompleteInfoUseCase sut = new CompleteInfoUseCase(memberRepository);
+
+    @Test
+    @DisplayName("온보딩 과정에서 사용자 추가 정보를 기입한다")
+    void success() {
+        // given
+        final Member member = new Member(MEMBER_1.getPlatform(), MEMBER_1.getName(), null, null).apply(1L);
+
+        final CompleteInfoCommand command = new CompleteInfoCommand(
+                member.getId(),
+                MEMBER_2.getName(),
+                MEMBER_1.getGender(),
+                MEMBER_1.getBirth()
+        );
+        given(memberRepository.getById(command.memberId())).willReturn(member);
+
+        // when
+        sut.invoke(command);
+
+        // then
+        assertAll(
+                () -> assertThat(member.getName()).isEqualTo(command.name()),
+                () -> assertThat(member.getGender()).isEqualTo(command.gender()),
+                () -> assertThat(member.getBirth()).isEqualTo(command.birth())
+        );
+    }
+}

--- a/src/test/java/ac/dnd/bookkeeping/server/member/application/usecase/ManageResourceUseCaseTest.java
+++ b/src/test/java/ac/dnd/bookkeeping/server/member/application/usecase/ManageResourceUseCaseTest.java
@@ -14,14 +14,14 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-@DisplayName("Member -> CompleteInfoUseCase 테스트")
-class CompleteInfoUseCaseTest extends UnitTest {
+@DisplayName("Member -> ManageResourceUseCase 테스트")
+class ManageResourceUseCaseTest extends UnitTest {
     private final MemberRepository memberRepository = mock(MemberRepository.class);
-    private final CompleteInfoUseCase sut = new CompleteInfoUseCase(memberRepository);
+    private final ManageResourceUseCase sut = new ManageResourceUseCase(memberRepository);
 
     @Test
     @DisplayName("온보딩 과정에서 사용자 추가 정보(닉네임, 성별, 생년월일)를 기입한다")
-    void success() {
+    void completeInfo() {
         // given
         final Member member = Member.create(MEMBER_1.getPlatform(), MEMBER_1.getProfileImageUrl()).apply(1L);
 
@@ -34,7 +34,7 @@ class CompleteInfoUseCaseTest extends UnitTest {
         given(memberRepository.getById(command.memberId())).willReturn(member);
 
         // when
-        sut.invoke(command);
+        sut.completeInfo(command);
 
         // then
         assertAll(

--- a/src/test/java/ac/dnd/bookkeeping/server/member/domain/model/MemberTest.java
+++ b/src/test/java/ac/dnd/bookkeeping/server/member/domain/model/MemberTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import static ac.dnd.bookkeeping.server.common.fixture.MemberFixture.MEMBER_1;
 import static ac.dnd.bookkeeping.server.common.fixture.MemberFixture.MEMBER_2;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("Member -> 도메인 Aggregate [Member] 테스트")
 class MemberTest extends UnitTest {
@@ -21,5 +22,27 @@ class MemberTest extends UnitTest {
 
         // then
         assertThat(member.getPlatform().getEmail().getValue()).isEqualTo(MEMBER_2.getPlatform().getEmail().getValue());
+    }
+
+    @Test
+    @DisplayName("온보딩 과정에서 추가 정보들을 기입한다")
+    void complete() {
+        // given
+        final Member member = new Member(MEMBER_1.getPlatform(), MEMBER_1.getName(), null, null);
+        assertAll(
+                () -> assertThat(member.getName()).isEqualTo(MEMBER_1.getName()),
+                () -> assertThat(member.getGender()).isNull(),
+                () -> assertThat(member.getBirth()).isNull()
+        );
+
+        // when
+        member.complete(MEMBER_2.getName(), MEMBER_1.getGender(), MEMBER_1.getBirth());
+
+        // then
+        assertAll(
+                () -> assertThat(member.getName()).isEqualTo(MEMBER_2.getName()),
+                () -> assertThat(member.getGender()).isEqualTo(MEMBER_1.getGender()),
+                () -> assertThat(member.getBirth()).isEqualTo(MEMBER_1.getBirth())
+        );
     }
 }

--- a/src/test/java/ac/dnd/bookkeeping/server/member/domain/model/MemberTest.java
+++ b/src/test/java/ac/dnd/bookkeeping/server/member/domain/model/MemberTest.java
@@ -1,0 +1,25 @@
+package ac.dnd.bookkeeping.server.member.domain.model;
+
+import ac.dnd.bookkeeping.server.common.UnitTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static ac.dnd.bookkeeping.server.common.fixture.MemberFixture.MEMBER_1;
+import static ac.dnd.bookkeeping.server.common.fixture.MemberFixture.MEMBER_2;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Member -> 도메인 Aggregate [Member] 테스트")
+class MemberTest extends UnitTest {
+    @Test
+    @DisplayName("카카오 계정의 경우 고객센터에서 이메일을 변경하는 경우 플랫폼에서 관리하는 이메일과 싱크를 맞춘다")
+    void syncEmail() {
+        // given
+        final Member member = MEMBER_1.toDomain();
+
+        // when
+        member.syncEmail(MEMBER_2.getPlatform().getEmail());
+
+        // then
+        assertThat(member.getPlatform().getEmail().getValue()).isEqualTo(MEMBER_2.getPlatform().getEmail().getValue());
+    }
+}

--- a/src/test/java/ac/dnd/bookkeeping/server/member/domain/model/MemberTest.java
+++ b/src/test/java/ac/dnd/bookkeeping/server/member/domain/model/MemberTest.java
@@ -25,22 +25,28 @@ class MemberTest extends UnitTest {
     }
 
     @Test
-    @DisplayName("온보딩 과정에서 추가 정보들을 기입한다")
+    @DisplayName("온보딩 과정에서 추가 정보들을 기입한다 (닉네임, 성별, 생년월일)")
     void complete() {
         // given
-        final Member member = new Member(MEMBER_1.getPlatform(), MEMBER_1.getName(), null, null);
+        final Member member = Member.create(MEMBER_1.getPlatform(), MEMBER_1.getProfileImageUrl());
         assertAll(
-                () -> assertThat(member.getName()).isEqualTo(MEMBER_1.getName()),
+                () -> assertThat(member.getPlatform().getSocialId()).isEqualTo(MEMBER_1.getPlatform().getSocialId()),
+                () -> assertThat(member.getPlatform().getEmail().getValue()).isEqualTo(MEMBER_1.getPlatform().getEmail().getValue()),
+                () -> assertThat(member.getProfileImageUrl()).isEqualTo(MEMBER_1.getProfileImageUrl()),
+                () -> assertThat(member.getNickname()).isNull(),
                 () -> assertThat(member.getGender()).isNull(),
                 () -> assertThat(member.getBirth()).isNull()
         );
 
         // when
-        member.complete(MEMBER_2.getName(), MEMBER_1.getGender(), MEMBER_1.getBirth());
+        member.complete(MEMBER_2.getNickname(), MEMBER_1.getGender(), MEMBER_1.getBirth());
 
         // then
         assertAll(
-                () -> assertThat(member.getName()).isEqualTo(MEMBER_2.getName()),
+                () -> assertThat(member.getPlatform().getSocialId()).isEqualTo(MEMBER_1.getPlatform().getSocialId()),
+                () -> assertThat(member.getPlatform().getEmail().getValue()).isEqualTo(MEMBER_1.getPlatform().getEmail().getValue()),
+                () -> assertThat(member.getProfileImageUrl()).isEqualTo(MEMBER_1.getProfileImageUrl()),
+                () -> assertThat(member.getNickname().getValue()).isEqualTo(MEMBER_2.getNickname().getValue()),
                 () -> assertThat(member.getGender()).isEqualTo(MEMBER_1.getGender()),
                 () -> assertThat(member.getBirth()).isEqualTo(MEMBER_1.getBirth())
         );

--- a/src/test/java/ac/dnd/bookkeeping/server/member/domain/model/NicknameTest.java
+++ b/src/test/java/ac/dnd/bookkeeping/server/member/domain/model/NicknameTest.java
@@ -1,0 +1,50 @@
+package ac.dnd.bookkeeping.server.member.domain.model;
+
+import ac.dnd.bookkeeping.server.common.UnitTest;
+import ac.dnd.bookkeeping.server.member.exception.MemberException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static ac.dnd.bookkeeping.server.member.exception.MemberExceptionCode.INVALID_NICKNAME_PATTERN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@DisplayName("Member -> 도메인 [Nickname] 테스트")
+class NicknameTest extends UnitTest {
+    @Nested
+    @DisplayName("Nickname 생성")
+    class Construct {
+        @ParameterizedTest
+        @ValueSource(strings = {"", "aaaaabbbbbcccccd", "H ell"})
+        @DisplayName("형식에 맞지 않는 Nickname이면 생성에 실패한다")
+        void throwExceptionByInvalidNicknameFormat(final String value) {
+            assertThatThrownBy(() -> Nickname.from(value))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessage(INVALID_NICKNAME_PATTERN.getMessage());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"하이", "Hello", "Hello하이123"})
+        @DisplayName("Nickname을 생성한다")
+        void construct(final String value) {
+            assertDoesNotThrow(() -> Nickname.from(value));
+        }
+    }
+
+    @Test
+    @DisplayName("닉네임을 수정한다")
+    void success() {
+        // given
+        final Nickname nickname = Nickname.from("Hello");
+
+        // when
+        final Nickname updateNickname = nickname.update("하이");
+
+        // then
+        assertThat(updateNickname.getValue()).isEqualTo("하이");
+    }
+}

--- a/src/test/java/ac/dnd/bookkeeping/server/member/domain/repository/MemberRepositoryTest.java
+++ b/src/test/java/ac/dnd/bookkeeping/server/member/domain/repository/MemberRepositoryTest.java
@@ -1,0 +1,42 @@
+package ac.dnd.bookkeeping.server.member.domain.repository;
+
+import ac.dnd.bookkeeping.server.common.RepositoryTest;
+import ac.dnd.bookkeeping.server.member.domain.model.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+import static ac.dnd.bookkeeping.server.common.fixture.MemberFixture.MEMBER_1;
+import static ac.dnd.bookkeeping.server.common.fixture.MemberFixture.MEMBER_2;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("Member -> MemberRepository 테스트")
+class MemberRepositoryTest extends RepositoryTest {
+    @Autowired
+    private MemberRepository sut;
+
+    @Test
+    @DisplayName("소셜 플랫폼 ID를 기반으로 사용자를 조회한다")
+    void findByPlatformSocialId() {
+        // given
+        final Member member1 = sut.save(MEMBER_1.toDomain());
+        final Member member2 = sut.save(MEMBER_2.toDomain());
+
+        // when
+        final Optional<Member> findMember1 = sut.findByPlatformSocialId(member1.getPlatform().getSocialId());
+        final Optional<Member> findMember2 = sut.findByPlatformSocialId(member1.getPlatform().getSocialId() + "diff");
+        final Optional<Member> findMember3 = sut.findByPlatformSocialId(member2.getPlatform().getSocialId());
+        final Optional<Member> findMember4 = sut.findByPlatformSocialId(member2.getPlatform().getSocialId() + "diff");
+
+        // then
+        assertAll(
+                () -> assertThat(findMember1).isPresent(),
+                () -> assertThat(findMember2).isEmpty(),
+                () -> assertThat(findMember3).isPresent(),
+                () -> assertThat(findMember4).isEmpty()
+        );
+    }
+}

--- a/src/test/java/ac/dnd/bookkeeping/server/member/domain/repository/MemberRepositoryTest.java
+++ b/src/test/java/ac/dnd/bookkeeping/server/member/domain/repository/MemberRepositoryTest.java
@@ -39,4 +39,21 @@ class MemberRepositoryTest extends RepositoryTest {
                 () -> assertThat(findMember4).isEmpty()
         );
     }
+
+    @Test
+    @DisplayName("닉네임이 사용중인지 확인한다")
+    void existsByNickname() {
+        // given
+        sut.save(MEMBER_1.toDomain());
+
+        // when
+        final boolean actual1 = sut.existsByNickname(MEMBER_1.getNickname());
+        final boolean actual2 = sut.existsByNickname(MEMBER_2.getNickname());
+
+        // then
+        assertAll(
+                () -> assertThat(actual1).isTrue(),
+                () -> assertThat(actual2).isFalse()
+        );
+    }
 }

--- a/src/test/java/ac/dnd/bookkeeping/server/member/presentation/ManageResourceApiControllerTest.java
+++ b/src/test/java/ac/dnd/bookkeeping/server/member/presentation/ManageResourceApiControllerTest.java
@@ -1,0 +1,91 @@
+package ac.dnd.bookkeeping.server.member.presentation;
+
+import ac.dnd.bookkeeping.server.common.ControllerTest;
+import ac.dnd.bookkeeping.server.member.application.usecase.ManageResourceUseCase;
+import ac.dnd.bookkeeping.server.member.domain.model.Member;
+import ac.dnd.bookkeeping.server.member.presentation.dto.request.CompleteInfoRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Map;
+
+import static ac.dnd.bookkeeping.server.common.fixture.MemberFixture.MEMBER_1;
+import static ac.dnd.bookkeeping.server.common.utils.RestDocsSpecificationUtils.SnippetFactory.body;
+import static ac.dnd.bookkeeping.server.common.utils.RestDocsSpecificationUtils.SnippetFactory.query;
+import static ac.dnd.bookkeeping.server.common.utils.RestDocsSpecificationUtils.createHttpSpecSnippets;
+import static ac.dnd.bookkeeping.server.common.utils.RestDocsSpecificationUtils.successDocs;
+import static ac.dnd.bookkeeping.server.common.utils.RestDocsSpecificationUtils.successDocsWithAccessToken;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Member -> ManageResourceApiController 테스트")
+class ManageResourceApiControllerTest extends ControllerTest {
+    @Autowired
+    private ManageResourceUseCase manageResourceUseCase;
+
+    @Nested
+    @DisplayName("닉네임 중복 체크 API [GET /api/v1/check-nickname]")
+    class CheckNickname {
+        private static final String BASE_URL = "/api/v1/check-nickname";
+
+        @Test
+        @DisplayName("닉네임 사용 가능 여부를 조회한다")
+        void success() {
+            // given
+            given(manageResourceUseCase.isUniqueNickname(any())).willReturn(true);
+
+            // when - then
+            successfulExecute(
+                    getRequest(BASE_URL, Map.of("nickname", "Hello")),
+                    status().isOk(),
+                    successDocs("MemberApi/Onboarding/CheckNickname", createHttpSpecSnippets(
+                            queryParameters(
+                                    query("nickname", "중복 체크할 닉네임", true)
+                            ),
+                            responseFields(
+                                    body("result", "닉네임 사용 가능 여부")
+                            )
+                    ))
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자 추가 정보 기입 API [POST /api/v1/members/me/complete]")
+    class CompleteInfo {
+        private static final String BASE_URL = "/api/v1/members/me/complete";
+
+        private final CompleteInfoRequest request = new CompleteInfoRequest(
+                MEMBER_1.getNickname().getValue(),
+                MEMBER_1.getGender().getValue(),
+                MEMBER_1.getBirth()
+        );
+        private final Member member = MEMBER_1.toDomain().apply(1L);
+
+        @Test
+        @DisplayName("온보딩 후 추가 정보를 기입한다")
+        void success() {
+            // given
+            applyToken(true, member.getId());
+
+            // when - then
+            successfulExecute(
+                    patchRequestWithAccessToken(BASE_URL, request),
+                    status().isNoContent(),
+                    successDocsWithAccessToken("MemberApi/Onboarding/CompleteInfo", createHttpSpecSnippets(
+                            requestFields(
+                                    body("nickname", "닉네임", true),
+                                    body("gender", "성별", "male / female", true),
+                                    body("birth", "생년월일", "LocalDate 형식 (yyyy-MM-dd)", true)
+                            )
+                    ))
+            );
+        }
+    }
+}


### PR DESCRIPTION
# Summary

- 로그인 API 구현 (socialId, email, profileImageUrl)
  - 처음 로그인한 사용자 = 회원가입 프로세스까지 진행한 후 로그인 처리
  - 이미 가입한 사용자 = 회원가입 프로세스 생략하고 로그인 처리
- 추가 정보 기입 API 구현
  - 닉네임 중복체크 API
  - 추가 정보 기입 API (닉네임, 성별, 생년월일)

## Related Issue

> Close #12

