### PR TITLE
[Feature] 사용자별 그룹명 수정 API를 구현한다

### DIFF
--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -90,6 +90,19 @@ include::{snippets}/GroupApi/Add/Success/request-fields.adoc[]
 include::{snippets}/GroupApi/Add/Failure/http-response.adoc[]
 include::{snippets}/GroupApi/Add/Success/http-response.adoc[]
 
+=== 수정
+
+> HTTP Request
+
+include::{snippets}/GroupApi/Update/Success/http-request.adoc[]
+include::{snippets}/GroupApi/Update/Success/path-parameters.adoc[]
+include::{snippets}/GroupApi/Update/Success/request-fields.adoc[]
+
+> HTTP Response
+
+include::{snippets}/GroupApi/Update/Failure/http-response.adoc[]
+include::{snippets}/GroupApi/Update/Success/http-response.adoc[]
+
 === 삭제
 
 > HTTP Request

--- a/src/main/java/ac/dnd/mur/server/group/application/usecase/UpdateGroupUseCase.java
+++ b/src/main/java/ac/dnd/mur/server/group/application/usecase/UpdateGroupUseCase.java
@@ -1,0 +1,30 @@
+package ac.dnd.mur.server.group.application.usecase;
+
+import ac.dnd.mur.server.global.annotation.MurWritableTransactional;
+import ac.dnd.mur.server.global.annotation.UseCase;
+import ac.dnd.mur.server.group.application.usecase.command.UpdateGroupCommand;
+import ac.dnd.mur.server.group.domain.model.Group;
+import ac.dnd.mur.server.group.domain.repository.GroupRepository;
+import ac.dnd.mur.server.group.exception.GroupException;
+import lombok.RequiredArgsConstructor;
+
+import static ac.dnd.mur.server.group.exception.GroupExceptionCode.GROUP_ALREADY_EXISTS;
+
+@UseCase
+@RequiredArgsConstructor
+public class UpdateGroupUseCase {
+    private final GroupRepository groupRepository;
+
+    @MurWritableTransactional
+    public void invoke(final UpdateGroupCommand command) {
+        final Group group = groupRepository.getMemberGroup(command.groupId(), command.memberId());
+        validateExistsGroup(group, command.memberId(), command.name());
+        group.update(command.name());
+    }
+
+    private void validateExistsGroup(final Group group, final long memberId, final String name) {
+        if (!group.getName().equals(name) && groupRepository.existsByMemberIdAndName(memberId, name)) {
+            throw new GroupException(GROUP_ALREADY_EXISTS);
+        }
+    }
+}

--- a/src/main/java/ac/dnd/mur/server/group/application/usecase/command/UpdateGroupCommand.java
+++ b/src/main/java/ac/dnd/mur/server/group/application/usecase/command/UpdateGroupCommand.java
@@ -1,0 +1,8 @@
+package ac.dnd.mur.server.group.application.usecase.command;
+
+public record UpdateGroupCommand(
+        long memberId,
+        long groupId,
+        String name
+) {
+}

--- a/src/main/java/ac/dnd/mur/server/group/domain/model/Group.java
+++ b/src/main/java/ac/dnd/mur/server/group/domain/model/Group.java
@@ -1,11 +1,10 @@
 package ac.dnd.mur.server.group.domain.model;
 
+import ac.dnd.mur.server.global.base.BaseEntity;
 import ac.dnd.mur.server.member.domain.model.Member;
 import ac.dnd.mur.server.member.exception.MemberException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,20 +12,15 @@ import lombok.NoArgsConstructor;
 import java.util.List;
 
 import static ac.dnd.mur.server.member.exception.MemberExceptionCode.MEMBER_GROUP_NAME_TOO_LONG;
-import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @Entity
 @Table(name = "member_group")
-public class Group {
+public class Group extends BaseEntity<Group> {
     private static final List<String> defaultGroups = List.of("친구", "가족", "지인", "직장");
     private static final int NAME_MAX_LENGTH = 8;
-
-    @Id
-    @GeneratedValue(strategy = IDENTITY)
-    private Long id;
 
     @Column(name = "member_id", nullable = false)
     private Long memberId;
@@ -54,5 +48,9 @@ public class Group {
         if (name.length() > NAME_MAX_LENGTH) {
             throw new MemberException(MEMBER_GROUP_NAME_TOO_LONG);
         }
+    }
+
+    public void update(final String name) {
+        this.name = name;
     }
 }

--- a/src/main/java/ac/dnd/mur/server/group/presentation/ManageGroupApiController.java
+++ b/src/main/java/ac/dnd/mur/server/group/presentation/ManageGroupApiController.java
@@ -6,10 +6,13 @@ import ac.dnd.mur.server.global.dto.ResponseWrapper;
 import ac.dnd.mur.server.group.application.usecase.AddGroupUseCase;
 import ac.dnd.mur.server.group.application.usecase.GetMemberGroupUseCase;
 import ac.dnd.mur.server.group.application.usecase.RemoveGroupUseCase;
+import ac.dnd.mur.server.group.application.usecase.UpdateGroupUseCase;
 import ac.dnd.mur.server.group.application.usecase.command.AddGroupCommand;
 import ac.dnd.mur.server.group.application.usecase.command.RemoveGroupCommand;
+import ac.dnd.mur.server.group.application.usecase.command.UpdateGroupCommand;
 import ac.dnd.mur.server.group.domain.model.GroupResponse;
 import ac.dnd.mur.server.group.presentation.dto.request.AddGroupRequest;
+import ac.dnd.mur.server.group.presentation.dto.request.UpdateGroupRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -17,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,6 +35,7 @@ import java.util.List;
 @RequestMapping("/api")
 public class ManageGroupApiController {
     private final AddGroupUseCase addGroupUseCase;
+    private final UpdateGroupUseCase updateGroupUseCase;
     private final RemoveGroupUseCase removeGroupUseCase;
     private final GetMemberGroupUseCase getMemberGroupUseCase;
 
@@ -45,6 +50,21 @@ public class ManageGroupApiController {
                 request.name()
         ));
         return ResponseEntity.ok(ResponseWrapper.from(groupId));
+    }
+
+    @Operation(summary = "그룹 수정 Endpoint")
+    @PatchMapping("/v1/groups/{groupId}")
+    public ResponseEntity<Void> updateGroup(
+            @Auth final Authenticated authenticated,
+            @PathVariable(name = "groupId") final Long groupId,
+            @RequestBody @Valid final UpdateGroupRequest request
+    ) {
+        updateGroupUseCase.invoke(new UpdateGroupCommand(
+                authenticated.id(),
+                groupId,
+                request.name()
+        ));
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "그룹 삭제 Endpoint")

--- a/src/main/java/ac/dnd/mur/server/group/presentation/dto/request/UpdateGroupRequest.java
+++ b/src/main/java/ac/dnd/mur/server/group/presentation/dto/request/UpdateGroupRequest.java
@@ -1,0 +1,9 @@
+package ac.dnd.mur.server.group.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateGroupRequest(
+        @NotBlank(message = "그룹 이름은 필수입니다.")
+        String name
+) {
+}

--- a/src/main/resources/db/migration/V2__create_member_group_table.sql
+++ b/src/main/resources/db/migration/V2__create_member_group_table.sql
@@ -1,8 +1,10 @@
 CREATE TABLE IF NOT EXISTS member_group
 (
-    id        BIGINT AUTO_INCREMENT PRIMARY KEY,
-    member_id BIGINT      NOT NULL,
-    name      VARCHAR(30) NOT NULL
+    id               BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id        BIGINT      NOT NULL,
+    name             VARCHAR(30) NOT NULL,
+    created_at       DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_modified_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4;
 

--- a/src/test/java/ac/dnd/mur/server/acceptance/group/GroupAcceptanceStep.java
+++ b/src/test/java/ac/dnd/mur/server/acceptance/group/GroupAcceptanceStep.java
@@ -2,6 +2,7 @@ package ac.dnd.mur.server.acceptance.group;
 
 import ac.dnd.mur.server.group.domain.model.GroupResponse;
 import ac.dnd.mur.server.group.presentation.dto.request.AddGroupRequest;
+import ac.dnd.mur.server.group.presentation.dto.request.UpdateGroupRequest;
 import io.restassured.response.ValidatableResponse;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -9,6 +10,7 @@ import java.util.List;
 
 import static ac.dnd.mur.server.acceptance.CommonRequestFixture.deleteRequestWithAccessToken;
 import static ac.dnd.mur.server.acceptance.CommonRequestFixture.getRequestWithAccessToken;
+import static ac.dnd.mur.server.acceptance.CommonRequestFixture.patchRequestWithAccessToken;
 import static ac.dnd.mur.server.acceptance.CommonRequestFixture.postRequestWithAccessToken;
 
 public class GroupAcceptanceStep {
@@ -29,6 +31,17 @@ public class GroupAcceptanceStep {
                 .extract()
                 .jsonPath()
                 .getLong("result");
+    }
+
+    public static ValidatableResponse 그룹을_수정한다(final long groupId, final String name, final String accessToken) {
+        final String uri = UriComponentsBuilder
+                .fromPath("/api/v1/groups/{groupId}")
+                .build(groupId)
+                .getPath();
+
+        final UpdateGroupRequest request = new UpdateGroupRequest(name);
+
+        return patchRequestWithAccessToken(uri, request, accessToken);
     }
 
     public static ValidatableResponse 그룹을_삭제한다(

--- a/src/test/java/ac/dnd/mur/server/acceptance/relation/ManageRelationAcceptanceTest.java
+++ b/src/test/java/ac/dnd/mur/server/acceptance/relation/ManageRelationAcceptanceTest.java
@@ -27,7 +27,7 @@ public class ManageRelationAcceptanceTest extends AcceptanceTest {
     @DisplayName("관계 생성 API")
     class Create {
         @Test
-        @DisplayName("그룹을 추가한다")
+        @DisplayName("관계를 생성한다")
         void success() {
             final AuthMember member = MEMBER_1.회원가입과_로그인을_진행한다();
 

--- a/src/test/java/ac/dnd/mur/server/group/application/usecase/UpdateGroupUseCaseTest.java
+++ b/src/test/java/ac/dnd/mur/server/group/application/usecase/UpdateGroupUseCaseTest.java
@@ -1,0 +1,83 @@
+package ac.dnd.mur.server.group.application.usecase;
+
+import ac.dnd.mur.server.common.UnitTest;
+import ac.dnd.mur.server.group.application.usecase.command.UpdateGroupCommand;
+import ac.dnd.mur.server.group.domain.model.Group;
+import ac.dnd.mur.server.group.domain.repository.GroupRepository;
+import ac.dnd.mur.server.group.exception.GroupException;
+import ac.dnd.mur.server.member.domain.model.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static ac.dnd.mur.server.common.fixture.GroupFixture.친구;
+import static ac.dnd.mur.server.common.fixture.MemberFixture.MEMBER_1;
+import static ac.dnd.mur.server.group.exception.GroupExceptionCode.GROUP_ALREADY_EXISTS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("Group -> UpdateGroupUseCase 테스트")
+class UpdateGroupUseCaseTest extends UnitTest {
+    private final GroupRepository groupRepository = mock(GroupRepository.class);
+    private final UpdateGroupUseCase sut = new UpdateGroupUseCase(groupRepository);
+
+    private final Member member = MEMBER_1.toDomain().apply(1L);
+    private final Group group = 친구.toDomain(member).apply(1L);
+
+    @Test
+    @DisplayName("현재 그룹명과 동일하지 않고 이미 관리하고 있는 그룹명이면 수정에 실패한다")
+    void throwExceptionByGroupAlreadyExists() {
+        // given
+        final UpdateGroupCommand command = new UpdateGroupCommand(
+                member.getId(),
+                group.getId(),
+                "거래처"
+        );
+        given(groupRepository.getMemberGroup(command.groupId(), command.memberId())).willReturn(group);
+        given(groupRepository.existsByMemberIdAndName(command.memberId(), command.name())).willReturn(true);
+
+        // when - then
+        assertThatThrownBy(() -> sut.invoke(command))
+                .isInstanceOf(GroupException.class)
+                .hasMessage(GROUP_ALREADY_EXISTS.getMessage());
+    }
+
+    @Test
+    @DisplayName("현재 그룹명과 동일한 이름으로 수정을 시도하면 유지한채로 성공한다")
+    void successWithKeep() {
+        // given
+        final UpdateGroupCommand command = new UpdateGroupCommand(
+                member.getId(),
+                group.getId(),
+                "친구"
+        );
+        given(groupRepository.getMemberGroup(command.groupId(), command.memberId())).willReturn(group);
+        given(groupRepository.existsByMemberIdAndName(command.memberId(), command.name())).willReturn(true);
+
+        // when
+        sut.invoke(command);
+
+        // then
+        assertThat(group.getName()).isEqualTo(command.name());
+    }
+
+    @Test
+    @DisplayName("현재 그룹명과 다른 이름으로 수정을 시도하면 성공한다")
+    void success() {
+        // given
+        final UpdateGroupCommand command = new UpdateGroupCommand(
+                member.getId(),
+                group.getId(),
+                "거래처"
+        );
+        given(groupRepository.getMemberGroup(command.groupId(), command.memberId())).willReturn(group);
+        given(groupRepository.existsByMemberIdAndName(command.memberId(), command.name())).willReturn(false);
+
+        // when
+        sut.invoke(command);
+
+        // then
+        assertThat(group.getName()).isEqualTo(command.name());
+    }
+}


### PR DESCRIPTION
# Summary

- 사용자별 그룹명 수정 API 구현
- Group 도메인 BaseEntity 추가에 따른 Flyway Schema 강제 재설정

## Related Issue

> Close #54

