### PR TITLE
[Feature] 등록한 관계에 대한 다건 조회 API를 구현한다

### DIFF
--- a/src/docs/asciidoc/relation.adoc
+++ b/src/docs/asciidoc/relation.adoc
@@ -52,3 +52,15 @@ include::{snippets}/RelationApi/Details/Single/path-parameters.adoc[]
 
 include::{snippets}/RelationApi/Details/Single/http-response.adoc[]
 include::{snippets}/RelationApi/Details/Single/response-fields.adoc[]
+
+=== N건
+
+*HTTP Request*
+
+include::{snippets}/RelationApi/Details/Multiple/http-request.adoc[]
+include::{snippets}/RelationApi/Details/Multiple/query-parameters.adoc[]
+
+*HTTP Response*
+
+include::{snippets}/RelationApi/Details/Multiple/http-response.adoc[]
+include::{snippets}/RelationApi/Details/Multiple/response-fields.adoc[]

--- a/src/main/java/ac/dnd/mur/server/relation/application/usecase/GetRelationDetailsUseCase.java
+++ b/src/main/java/ac/dnd/mur/server/relation/application/usecase/GetRelationDetailsUseCase.java
@@ -3,10 +3,14 @@ package ac.dnd.mur.server.relation.application.usecase;
 import ac.dnd.mur.server.global.annotation.MurReadOnlyTransactional;
 import ac.dnd.mur.server.global.annotation.UseCase;
 import ac.dnd.mur.server.heart.domain.repository.HeartRepository;
+import ac.dnd.mur.server.relation.application.usecase.query.GetMultipleRelationDetails;
 import ac.dnd.mur.server.relation.application.usecase.query.GetSingleRelationDetails;
+import ac.dnd.mur.server.relation.application.usecase.query.response.MultipleRelationDetails;
 import ac.dnd.mur.server.relation.application.usecase.query.response.SingleRelationDetails;
 import ac.dnd.mur.server.relation.domain.repository.query.RelationDetailsQueryRepository;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
 
 @UseCase
 @RequiredArgsConstructor
@@ -17,9 +21,17 @@ public class GetRelationDetailsUseCase {
     @MurReadOnlyTransactional
     public SingleRelationDetails getRelation(final GetSingleRelationDetails query) {
         return SingleRelationDetails.of(
-                relationDetailsQueryRepository.fetchRelation(query.relationId()),
+                relationDetailsQueryRepository.fetchRelation(query.relationId(), query.memberId()),
                 heartRepository.fetchInteractionMoney(query.memberId(), query.relationId(), true),
                 heartRepository.fetchInteractionMoney(query.memberId(), query.relationId(), false)
         );
+    }
+
+    @MurReadOnlyTransactional
+    public List<MultipleRelationDetails> getRelations(final GetMultipleRelationDetails query) {
+        return relationDetailsQueryRepository.fetchRelations(query.memberId(), query.name())
+                .stream()
+                .map(MultipleRelationDetails::from)
+                .toList();
     }
 }

--- a/src/main/java/ac/dnd/mur/server/relation/application/usecase/query/GetMultipleRelationDetails.java
+++ b/src/main/java/ac/dnd/mur/server/relation/application/usecase/query/GetMultipleRelationDetails.java
@@ -1,0 +1,7 @@
+package ac.dnd.mur.server.relation.application.usecase.query;
+
+public record GetMultipleRelationDetails(
+        long memberId,
+        String name
+) {
+}

--- a/src/main/java/ac/dnd/mur/server/relation/application/usecase/query/response/MultipleRelationDetails.java
+++ b/src/main/java/ac/dnd/mur/server/relation/application/usecase/query/response/MultipleRelationDetails.java
@@ -1,0 +1,18 @@
+package ac.dnd.mur.server.relation.application.usecase.query.response;
+
+import ac.dnd.mur.server.group.domain.model.GroupResponse;
+import ac.dnd.mur.server.relation.domain.repository.query.response.RelationDetails;
+
+public record MultipleRelationDetails(
+        long id,
+        String name,
+        GroupResponse group
+) {
+    public static MultipleRelationDetails from(final RelationDetails details) {
+        return new MultipleRelationDetails(
+                details.id(),
+                details.name(),
+                new GroupResponse(details.groupId(), details.groupName())
+        );
+    }
+}

--- a/src/main/java/ac/dnd/mur/server/relation/domain/repository/query/RelationDetailsQueryRepository.java
+++ b/src/main/java/ac/dnd/mur/server/relation/domain/repository/query/RelationDetailsQueryRepository.java
@@ -2,6 +2,10 @@ package ac.dnd.mur.server.relation.domain.repository.query;
 
 import ac.dnd.mur.server.relation.domain.repository.query.response.RelationDetails;
 
+import java.util.List;
+
 public interface RelationDetailsQueryRepository {
-    RelationDetails fetchRelation(final long id);
+    RelationDetails fetchRelation(final long id, final long memberId);
+
+    List<RelationDetails> fetchRelations(final long memberId, final String name);
 }

--- a/src/main/java/ac/dnd/mur/server/relation/domain/repository/query/RelationDetailsQueryRepositoryImpl.java
+++ b/src/main/java/ac/dnd/mur/server/relation/domain/repository/query/RelationDetailsQueryRepositoryImpl.java
@@ -3,12 +3,18 @@ package ac.dnd.mur.server.relation.domain.repository.query;
 import ac.dnd.mur.server.global.annotation.MurReadOnlyTransactional;
 import ac.dnd.mur.server.relation.domain.repository.query.response.QRelationDetails;
 import ac.dnd.mur.server.relation.domain.repository.query.response.RelationDetails;
+import ac.dnd.mur.server.relation.exception.RelationException;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
 
 import static ac.dnd.mur.server.group.domain.model.QGroup.group;
 import static ac.dnd.mur.server.relation.domain.model.QRelation.relation;
+import static ac.dnd.mur.server.relation.exception.RelationExceptionCode.RELATION_NOT_FOUND;
 
 @Repository
 @MurReadOnlyTransactional
@@ -17,7 +23,30 @@ public class RelationDetailsQueryRepositoryImpl implements RelationDetailsQueryR
     private final JPAQueryFactory query;
 
     @Override
-    public RelationDetails fetchRelation(final long id) {
+    public RelationDetails fetchRelation(final long id, final long memberId) {
+        final RelationDetails result = query
+                .select(new QRelationDetails(
+                        relation.id,
+                        relation.name,
+                        group.id,
+                        group.name
+                ))
+                .from(relation)
+                .innerJoin(group).on(group.id.eq(relation.groupId))
+                .where(
+                        relation.id.eq(id),
+                        relation.memberId.eq(memberId)
+                )
+                .fetchOne();
+
+        if (result == null) {
+            throw new RelationException(RELATION_NOT_FOUND);
+        }
+        return result;
+    }
+
+    @Override
+    public List<RelationDetails> fetchRelations(final long memberId, final String name) {
         return query
                 .select(new QRelationDetails(
                         relation.id,
@@ -27,7 +56,18 @@ public class RelationDetailsQueryRepositoryImpl implements RelationDetailsQueryR
                 ))
                 .from(relation)
                 .innerJoin(group).on(group.id.eq(relation.groupId))
-                .where(relation.id.eq(id))
-                .fetchOne();
+                .where(
+                        relation.memberId.eq(memberId),
+                        relationNameEq(name)
+                )
+                .orderBy(relation.id.desc())
+                .fetch();
+    }
+
+    private BooleanExpression relationNameEq(final String name) {
+        if (StringUtils.hasText(name)) {
+            return relation.name.eq(name);
+        }
+        return null;
     }
 }

--- a/src/main/java/ac/dnd/mur/server/relation/presentation/GetRelationDetailsApiController.java
+++ b/src/main/java/ac/dnd/mur/server/relation/presentation/GetRelationDetailsApiController.java
@@ -2,8 +2,11 @@ package ac.dnd.mur.server.relation.presentation;
 
 import ac.dnd.mur.server.auth.domain.model.Authenticated;
 import ac.dnd.mur.server.global.annotation.Auth;
+import ac.dnd.mur.server.global.dto.ResponseWrapper;
 import ac.dnd.mur.server.relation.application.usecase.GetRelationDetailsUseCase;
+import ac.dnd.mur.server.relation.application.usecase.query.GetMultipleRelationDetails;
 import ac.dnd.mur.server.relation.application.usecase.query.GetSingleRelationDetails;
+import ac.dnd.mur.server.relation.application.usecase.query.response.MultipleRelationDetails;
 import ac.dnd.mur.server.relation.application.usecase.query.response.SingleRelationDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,7 +15,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @Tag(name = "등록한 관계 관련 정보 조회 API")
 @RestController
@@ -32,5 +38,18 @@ public class GetRelationDetailsApiController {
                 relationId
         ));
         return ResponseEntity.ok(result);
+    }
+
+    @Operation(summary = "N건 관계 정보 조회 Endpoint")
+    @GetMapping("/v1/relations/me")
+    public ResponseEntity<ResponseWrapper<List<MultipleRelationDetails>>> getRelations(
+            @Auth final Authenticated authenticated,
+            @RequestParam(name = "name", required = false) final String name
+    ) {
+        final List<MultipleRelationDetails> result = getRelationDetailsUseCase.getRelations(new GetMultipleRelationDetails(
+                authenticated.id(),
+                name
+        ));
+        return ResponseEntity.ok(ResponseWrapper.from(result));
     }
 }

--- a/src/test/java/ac/dnd/mur/server/acceptance/relation/GetRelationDetailsAcceptanceTest.java
+++ b/src/test/java/ac/dnd/mur/server/acceptance/relation/GetRelationDetailsAcceptanceTest.java
@@ -3,13 +3,18 @@ package ac.dnd.mur.server.acceptance.relation;
 import ac.dnd.mur.server.auth.domain.model.AuthMember;
 import ac.dnd.mur.server.common.AcceptanceTest;
 import ac.dnd.mur.server.common.containers.callback.DatabaseCleanerEachCallbackExtension;
+import ac.dnd.mur.server.group.domain.model.GroupResponse;
+import io.restassured.response.ValidatableResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.List;
+
 import static ac.dnd.mur.server.acceptance.group.GroupAcceptanceStep.관리하고_있는_특정_그룹의_ID를_조회한다;
 import static ac.dnd.mur.server.acceptance.heart.HeartAcceptanceStep.마음을_생성한다;
+import static ac.dnd.mur.server.acceptance.relation.RelationAcceptanceStep.관계_N건_정보를_조회한다;
 import static ac.dnd.mur.server.acceptance.relation.RelationAcceptanceStep.관계_단건_정보를_조회한다;
 import static ac.dnd.mur.server.acceptance.relation.RelationAcceptanceStep.관계를_생성하고_ID를_추출한다;
 import static ac.dnd.mur.server.common.fixture.HeartFixture.결혼_축의금을_받았다;
@@ -17,6 +22,7 @@ import static ac.dnd.mur.server.common.fixture.HeartFixture.생일_선물을_받
 import static ac.dnd.mur.server.common.fixture.HeartFixture.승진_선물을_보냈다;
 import static ac.dnd.mur.server.common.fixture.MemberFixture.MEMBER_1;
 import static ac.dnd.mur.server.common.fixture.RelationFixture.친구_1;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.http.HttpStatus.OK;
 
@@ -27,7 +33,7 @@ public class GetRelationDetailsAcceptanceTest extends AcceptanceTest {
     @DisplayName("등록한 관계 단건 조회 API")
     class GetRelation {
         @Test
-        @DisplayName("등록한 단건 관계에 대한 정보를 조회한다")
+        @DisplayName("등록한 관계에 대한 단건 정보를 조회한다")
         void success() {
             final AuthMember member = MEMBER_1.회원가입과_로그인을_진행한다();
             final long groupId = 관리하고_있는_특정_그룹의_ID를_조회한다("친구", member.accessToken());
@@ -77,6 +83,79 @@ public class GetRelationDetailsAcceptanceTest extends AcceptanceTest {
                     .body("group.name", is("친구"))
                     .body("giveMoney", is((int) 승진_선물을_보냈다.getMoney()))
                     .body("takeMoney", is((int) (결혼_축의금을_받았다.getMoney() + 생일_선물을_받았다.getMoney())));
+        }
+    }
+
+    @Nested
+    @DisplayName("등록한 관계 N건 조회 API")
+    class GetRelations {
+        @Test
+        @DisplayName("등록한 관계에 대한 N건 정보를 조회한다")
+        void success() {
+            final AuthMember member = MEMBER_1.회원가입과_로그인을_진행한다();
+            final long groupId1 = 관리하고_있는_특정_그룹의_ID를_조회한다("친구", member.accessToken());
+            final long groupId2 = 관리하고_있는_특정_그룹의_ID를_조회한다("가족", member.accessToken());
+            final long groupId3 = 관리하고_있는_특정_그룹의_ID를_조회한다("직장", member.accessToken());
+            final long relationId1 = 관계를_생성하고_ID를_추출한다(groupId1, "관계이름1", null, "이름1-메모..", member.accessToken());
+            final long relationId2 = 관계를_생성하고_ID를_추출한다(groupId1, "관계이름2", null, "이름2-메모..", member.accessToken());
+            final long relationId3 = 관계를_생성하고_ID를_추출한다(groupId2, "관계이름1", null, "이름1-메모..", member.accessToken());
+            final long relationId4 = 관계를_생성하고_ID를_추출한다(groupId3, "관계이름1", null, "이름1-메모..", member.accessToken());
+
+            final ValidatableResponse response1 = 관계_N건_정보를_조회한다(null, member.accessToken()).statusCode(OK.value());
+            assertRelationsMatch(
+                    response1,
+                    List.of(relationId4, relationId3, relationId2, relationId1),
+                    List.of("관계이름1", "관계이름1", "관계이름2", "관계이름1"),
+                    List.of(
+                            new GroupResponse(groupId3, "직장"),
+                            new GroupResponse(groupId2, "가족"),
+                            new GroupResponse(groupId1, "친구"),
+                            new GroupResponse(groupId1, "친구")
+                    )
+            );
+
+            final ValidatableResponse response2 = 관계_N건_정보를_조회한다("관계이름1", member.accessToken()).statusCode(OK.value());
+            assertRelationsMatch(
+                    response2,
+                    List.of(relationId4, relationId3, relationId1),
+                    List.of("관계이름1", "관계이름1", "관계이름1"),
+                    List.of(
+                            new GroupResponse(groupId3, "직장"),
+                            new GroupResponse(groupId2, "가족"),
+                            new GroupResponse(groupId1, "친구")
+                    )
+            );
+
+            final ValidatableResponse response3 = 관계_N건_정보를_조회한다("관계이름2", member.accessToken()).statusCode(OK.value());
+            assertRelationsMatch(
+                    response3,
+                    List.of(relationId2),
+                    List.of("관계이름2"),
+                    List.of(new GroupResponse(groupId1, "친구"))
+            );
+        }
+    }
+
+    private void assertRelationsMatch(
+            final ValidatableResponse response,
+            final List<Long> ids,
+            final List<String> names,
+            final List<GroupResponse> groups
+    ) {
+        final int totalSize = ids.size();
+        response.body("result", hasSize(totalSize));
+
+        for (int i = 0; i < totalSize; i++) {
+            final String index = String.format("result[%d]", i);
+            final Long id = ids.get(i);
+            final String name = names.get(i);
+            final GroupResponse group = groups.get(i);
+
+            response
+                    .body(index + ".id", is(id.intValue()))
+                    .body(index + ".name", is(name))
+                    .body(index + ".group.id", is((int) group.id()))
+                    .body(index + ".group.name", is(group.name()));
         }
     }
 }

--- a/src/test/java/ac/dnd/mur/server/acceptance/relation/RelationAcceptanceStep.java
+++ b/src/test/java/ac/dnd/mur/server/acceptance/relation/RelationAcceptanceStep.java
@@ -83,4 +83,16 @@ public class RelationAcceptanceStep {
 
         return getRequestWithAccessToken(uri, accessToken);
     }
+
+    public static ValidatableResponse 관계_N건_정보를_조회한다(
+            final String name,
+            final String accessToken
+    ) {
+        final String uri = UriComponentsBuilder
+                .fromPath("/api/v1/relations/me?name={name}")
+                .build(name)
+                .getPath();
+
+        return getRequestWithAccessToken(uri, accessToken);
+    }
 }

--- a/src/test/java/ac/dnd/mur/server/relation/presentation/GetRelationDetailsApiControllerTest.java
+++ b/src/test/java/ac/dnd/mur/server/relation/presentation/GetRelationDetailsApiControllerTest.java
@@ -4,22 +4,28 @@ import ac.dnd.mur.server.common.ControllerTest;
 import ac.dnd.mur.server.group.domain.model.GroupResponse;
 import ac.dnd.mur.server.member.domain.model.Member;
 import ac.dnd.mur.server.relation.application.usecase.GetRelationDetailsUseCase;
+import ac.dnd.mur.server.relation.application.usecase.query.response.MultipleRelationDetails;
 import ac.dnd.mur.server.relation.application.usecase.query.response.SingleRelationDetails;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.List;
+import java.util.Map;
+
 import static ac.dnd.mur.server.common.fixture.MemberFixture.MEMBER_1;
 import static ac.dnd.mur.server.common.fixture.RelationFixture.친구_1;
 import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.SnippetFactory.body;
 import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.SnippetFactory.path;
+import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.SnippetFactory.query;
 import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.createHttpSpecSnippets;
 import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.successDocs;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("Relation -> GetRelationDetailsApiController 테스트")
@@ -30,12 +36,12 @@ class GetRelationDetailsApiControllerTest extends ControllerTest {
     private final Member member = MEMBER_1.toDomain().apply(1L);
 
     @Nested
-    @DisplayName("등록한 단건 관계 조회 API [GET /api/v1/relations/me/{relationId}]")
+    @DisplayName("등록한 관계 단건 조회 API [GET /api/v1/relations/me/{relationId}]")
     class GetRelation {
         private static final String BASE_URL = "/api/v1/relations/me/{relationId}";
 
         @Test
-        @DisplayName("등록한 단건 관계에 대한 정보를 조회한다")
+        @DisplayName("등록한 관계에 대한 단건 정보를 조회한다")
         void success() {
             // given
             applyToken(true, member);
@@ -62,6 +68,41 @@ class GetRelationDetailsApiControllerTest extends ControllerTest {
                                     body("group.name", "그룹명"),
                                     body("giveMoney", "보낸 금액"),
                                     body("takeMoney", "받은 금액")
+                            )
+                    ))
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("등록한 관계 N건 조회 API [GET /api/v1/relations/me")
+    class GetRelations {
+        private static final String BASE_URL = "/api/v1/relations/me";
+
+        @Test
+        @DisplayName("등록한 관계에 대한 N건 정보를 조회한다")
+        void success() {
+            // given
+            applyToken(true, member);
+            given(getRelationDetailsUseCase.getRelations(any())).willReturn(List.of(
+                    new MultipleRelationDetails(3L, "HelloUser", new GroupResponse(4L, "직장")),
+                    new MultipleRelationDetails(2L, "HelloUser", new GroupResponse(2L, "가족")),
+                    new MultipleRelationDetails(1L, "HelloUser", new GroupResponse(1L, "친구"))
+            ));
+
+            // when - then
+            successfulExecute(
+                    getRequestWithAccessToken(new UrlWithVariables(BASE_URL, 1L), Map.of("name", "HelloUser")),
+                    status().isOk(),
+                    successDocs("RelationApi/Details/Multiple", createHttpSpecSnippets(
+                            queryParameters(
+                                    query("name", "검색할 이름", "관계 등록할 때 적용한 이름으로 조회", false)
+                            ),
+                            responseFields(
+                                    body("result[].id", "관계 ID(PK)"),
+                                    body("result[].name", "등록한 관계 이름"),
+                                    body("result[].group.id", "그룹 ID(PK)"),
+                                    body("result[].group.name", "그룹명")
                             )
                     ))
             );


### PR DESCRIPTION
# Summary

- 등록한 관계에 대한 다건 조회 API 구현
  - 관계 등록할 때 적용한 이름 필터링 Optional

## Related Issue

> Close #37

