### PR TITLE
[Feature] 지출이 기록되지 않은 일정 조회 API를 구현한다

### DIFF
--- a/src/docs/asciidoc/schedule.adoc
+++ b/src/docs/asciidoc/schedule.adoc
@@ -38,3 +38,18 @@ include::{snippets}/ScheduleApi/Delete/path-parameters.adoc[]
 *HTTP Response*
 
 include::{snippets}/ScheduleApi/Delete/http-response.adoc[]
+
+== 지출(보낸 마음)이 기록되지 않은 일정 조회
+
+TIP: 하루 이상 지난 일정에 대해서만 필터링
+
+IMPORTANT: 일정(Schedule) & 마음(Heart)에 대해서 [relationId, day, event]를 기준으로 공통 레코드 필터링
+
+*HTTP Request*
+
+include::{snippets}/ScheduleApi/UnrecordedHeart/http-request.adoc[]
+
+*HTTP Response*
+
+include::{snippets}/ScheduleApi/UnrecordedHeart/http-response.adoc[]
+include::{snippets}/ScheduleApi/UnrecordedHeart/response-fields.adoc[]

--- a/src/main/java/ac/dnd/mur/server/heart/domain/repository/HeartRepository.java
+++ b/src/main/java/ac/dnd/mur/server/heart/domain/repository/HeartRepository.java
@@ -55,4 +55,6 @@ public interface HeartRepository extends JpaRepository<Heart, Long> {
         return findByIdAndMemberId(id, memberId)
                 .orElseThrow(() -> new HeartException(HEART_NOT_FOUND));
     }
+
+    List<Heart> findByRelationIdIn(final List<Long> relationIds);
 }

--- a/src/main/java/ac/dnd/mur/server/schedule/application/usecase/GetUnrecordedScheduleUseCase.java
+++ b/src/main/java/ac/dnd/mur/server/schedule/application/usecase/GetUnrecordedScheduleUseCase.java
@@ -1,0 +1,75 @@
+package ac.dnd.mur.server.schedule.application.usecase;
+
+import ac.dnd.mur.server.global.annotation.MurReadOnlyTransactional;
+import ac.dnd.mur.server.global.annotation.UseCase;
+import ac.dnd.mur.server.heart.domain.model.Heart;
+import ac.dnd.mur.server.heart.domain.repository.HeartRepository;
+import ac.dnd.mur.server.schedule.application.usecase.query.response.UnrecordedScheduleResponse;
+import ac.dnd.mur.server.schedule.domain.model.Schedule;
+import ac.dnd.mur.server.schedule.domain.repository.ScheduleRepository;
+import ac.dnd.mur.server.schedule.domain.repository.query.ScheduleQueryRepository;
+import ac.dnd.mur.server.schedule.domain.service.UnrecordedStandardDefiner;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetUnrecordedScheduleUseCase {
+    private final UnrecordedStandardDefiner unrecordedStandardDefiner;
+    private final ScheduleRepository scheduleRepository;
+    private final HeartRepository heartRepository;
+    private final ScheduleQueryRepository scheduleQueryRepository;
+
+    @MurReadOnlyTransactional
+    public List<UnrecordedScheduleResponse> invoke(final long memberId) {
+        final List<Schedule> passedSchedules = scheduleRepository.getPassedSchedules(memberId, unrecordedStandardDefiner.get());
+        final List<Heart> registeredHearts = getRegisteredHeart(passedSchedules);
+
+        final List<Long> filteredScheduleIds = filteringPassedSchedules(passedSchedules, registeredHearts);
+        return scheduleQueryRepository.fetchUnrecordedSchedules(filteredScheduleIds)
+                .stream()
+                .map(UnrecordedScheduleResponse::from)
+                .toList();
+    }
+
+    private List<Heart> getRegisteredHeart(final List<Schedule> passedSchedules) {
+        final List<Long> relationIds = passedSchedules.stream()
+                .map(Schedule::getRelationId)
+                .toList();
+        return heartRepository.findByRelationIdIn(relationIds);
+    }
+
+    private List<Long> filteringPassedSchedules(
+            final List<Schedule> passedSchedules,
+            final List<Heart> registeredHearts
+    ) {
+        final List<Long> registeredIds = new ArrayList<>();
+        passedSchedules.forEach(schedule ->
+                registeredHearts.stream()
+                        .filter(sameRelation(schedule))
+                        .filter(sameDayAndEvent(schedule))
+                        .map(Heart::getRelationId)
+                        .forEach(registeredIds::add)
+        );
+
+        return passedSchedules.stream()
+                .filter(notRegisteredSchedules(registeredIds))
+                .map(Schedule::getId)
+                .toList();
+    }
+
+    private Predicate<Heart> sameRelation(final Schedule schedule) {
+        return heart -> schedule.getRelationId().equals(heart.getRelationId());
+    }
+
+    private Predicate<Heart> sameDayAndEvent(final Schedule schedule) {
+        return heart -> schedule.getDay().equals(heart.getDay()) && schedule.getEvent().equals(heart.getEvent());
+    }
+
+    private Predicate<Schedule> notRegisteredSchedules(final List<Long> registeredIds) {
+        return schedule -> !registeredIds.contains(schedule.getRelationId());
+    }
+}

--- a/src/main/java/ac/dnd/mur/server/schedule/application/usecase/query/response/UnrecordedScheduleResponse.java
+++ b/src/main/java/ac/dnd/mur/server/schedule/application/usecase/query/response/UnrecordedScheduleResponse.java
@@ -1,0 +1,40 @@
+package ac.dnd.mur.server.schedule.application.usecase.query.response;
+
+import ac.dnd.mur.server.group.domain.model.GroupResponse;
+import ac.dnd.mur.server.schedule.domain.repository.query.response.UnrecordedSchedule;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record UnrecordedScheduleResponse(
+        long id,
+        RelationSummary relation,
+        LocalDate day,
+        String event,
+        LocalTime time,
+        String link,
+        String location
+) {
+    public record RelationSummary(
+            long id,
+            String name,
+            GroupResponse group
+    ) {
+    }
+
+    public static UnrecordedScheduleResponse from(final UnrecordedSchedule schedule) {
+        return new UnrecordedScheduleResponse(
+                schedule.id(),
+                new RelationSummary(
+                        schedule.relationId(),
+                        schedule.relationName(),
+                        new GroupResponse(schedule.groupid(), schedule.groupName())
+                ),
+                schedule.day(),
+                schedule.event(),
+                schedule.time(),
+                schedule.link(),
+                schedule.location()
+        );
+    }
+}

--- a/src/main/java/ac/dnd/mur/server/schedule/domain/repository/ScheduleRepository.java
+++ b/src/main/java/ac/dnd/mur/server/schedule/domain/repository/ScheduleRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import static ac.dnd.mur.server.schedule.exception.ScheduleExceptionCode.SCHEDULE_NOT_FOUND;
@@ -18,6 +20,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
                 .orElseThrow(() -> new ScheduleException(SCHEDULE_NOT_FOUND));
     }
 
+    // @Query
     @MurWritableTransactional
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("DELETE FROM Schedule s WHERE s.id = :id AND s.memberId = :memberId")
@@ -27,6 +30,16 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("DELETE FROM Schedule s WHERE s.memberId = :memberId")
     void deleteMemberSchedules(@Param("memberId") final long memberId);
+
+    // Query Method
+    List<Schedule> findByMemberIdAndDayBefore(final long memberId, final LocalDate day);
+
+    /**
+     * 현재 날짜 기준 1일
+     */
+    default List<Schedule> getPassedSchedules(final long memberId, final LocalDate currentDay) {
+        return findByMemberIdAndDayBefore(memberId, currentDay);
+    }
 
     Optional<Schedule> findByIdAndMemberId(final long id, final long memberId);
 

--- a/src/main/java/ac/dnd/mur/server/schedule/domain/repository/query/ScheduleQueryRepository.java
+++ b/src/main/java/ac/dnd/mur/server/schedule/domain/repository/query/ScheduleQueryRepository.java
@@ -1,0 +1,9 @@
+package ac.dnd.mur.server.schedule.domain.repository.query;
+
+import ac.dnd.mur.server.schedule.domain.repository.query.response.UnrecordedSchedule;
+
+import java.util.List;
+
+public interface ScheduleQueryRepository {
+    List<UnrecordedSchedule> fetchUnrecordedSchedules(final List<Long> scheduleIds);
+}

--- a/src/main/java/ac/dnd/mur/server/schedule/domain/repository/query/ScheduleQueryRepositoryImpl.java
+++ b/src/main/java/ac/dnd/mur/server/schedule/domain/repository/query/ScheduleQueryRepositoryImpl.java
@@ -1,0 +1,44 @@
+package ac.dnd.mur.server.schedule.domain.repository.query;
+
+import ac.dnd.mur.server.global.annotation.MurReadOnlyTransactional;
+import ac.dnd.mur.server.schedule.domain.repository.query.response.QUnrecordedSchedule;
+import ac.dnd.mur.server.schedule.domain.repository.query.response.UnrecordedSchedule;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static ac.dnd.mur.server.group.domain.model.QGroup.group;
+import static ac.dnd.mur.server.relation.domain.model.QRelation.relation;
+import static ac.dnd.mur.server.schedule.domain.model.QSchedule.schedule;
+
+@Repository
+@MurReadOnlyTransactional
+@RequiredArgsConstructor
+public class ScheduleQueryRepositoryImpl implements ScheduleQueryRepository {
+    private final JPAQueryFactory query;
+
+    @Override
+    public List<UnrecordedSchedule> fetchUnrecordedSchedules(final List<Long> scheduleIds) {
+        return query
+                .select(new QUnrecordedSchedule(
+                        schedule.id,
+                        relation.id,
+                        relation.name,
+                        group.id,
+                        group.name,
+                        schedule.day,
+                        schedule.event,
+                        schedule.time,
+                        schedule.link,
+                        schedule.location
+                ))
+                .from(schedule)
+                .innerJoin(relation).on(relation.id.eq(schedule.relationId))
+                .innerJoin(group).on(group.id.eq(relation.groupId))
+                .where(schedule.id.in(scheduleIds))
+                .orderBy(schedule.id.asc())
+                .fetch();
+    }
+}

--- a/src/main/java/ac/dnd/mur/server/schedule/domain/repository/query/response/UnrecordedSchedule.java
+++ b/src/main/java/ac/dnd/mur/server/schedule/domain/repository/query/response/UnrecordedSchedule.java
@@ -1,0 +1,23 @@
+package ac.dnd.mur.server.schedule.domain.repository.query.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record UnrecordedSchedule(
+        long id,
+        long relationId,
+        String relationName,
+        long groupid,
+        String groupName,
+        LocalDate day,
+        String event,
+        LocalTime time,
+        String link,
+        String location
+) {
+    @QueryProjection
+    public UnrecordedSchedule {
+    }
+}

--- a/src/main/java/ac/dnd/mur/server/schedule/domain/service/DefaultUnrecordedStandardDefiner.java
+++ b/src/main/java/ac/dnd/mur/server/schedule/domain/service/DefaultUnrecordedStandardDefiner.java
@@ -1,0 +1,16 @@
+package ac.dnd.mur.server.schedule.domain.service;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+public class DefaultUnrecordedStandardDefiner implements UnrecordedStandardDefiner {
+    /**
+     * 현재 날짜 기준 1일 전에 종료된 지출이 기록되지 않은 일정
+     */
+    @Override
+    public LocalDate get() {
+        return LocalDate.now().minusDays(1);
+    }
+}

--- a/src/main/java/ac/dnd/mur/server/schedule/domain/service/UnrecordedStandardDefiner.java
+++ b/src/main/java/ac/dnd/mur/server/schedule/domain/service/UnrecordedStandardDefiner.java
@@ -1,0 +1,8 @@
+package ac.dnd.mur.server.schedule.domain.service;
+
+import java.time.LocalDate;
+
+@FunctionalInterface
+public interface UnrecordedStandardDefiner {
+    LocalDate get();
+}

--- a/src/main/java/ac/dnd/mur/server/schedule/presentation/GetUnrecordedScheduleApiController.java
+++ b/src/main/java/ac/dnd/mur/server/schedule/presentation/GetUnrecordedScheduleApiController.java
@@ -1,0 +1,33 @@
+package ac.dnd.mur.server.schedule.presentation;
+
+import ac.dnd.mur.server.auth.domain.model.Authenticated;
+import ac.dnd.mur.server.global.annotation.Auth;
+import ac.dnd.mur.server.global.dto.ResponseWrapper;
+import ac.dnd.mur.server.schedule.application.usecase.GetUnrecordedScheduleUseCase;
+import ac.dnd.mur.server.schedule.application.usecase.query.response.UnrecordedScheduleResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "지출(보낸 마음)이 기록되지 않은 일정 조회 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class GetUnrecordedScheduleApiController {
+    private final GetUnrecordedScheduleUseCase getUnrecordedScheduleUseCase;
+
+    @Operation(summary = "지출(보낸 마음)이 기록되지 않은 일정 조회 Endpoint")
+    @GetMapping("/v1/schedules/unrecorded")
+    public ResponseEntity<ResponseWrapper<List<UnrecordedScheduleResponse>>> getUnrecordedSchedule(
+            @Auth final Authenticated authenticated
+    ) {
+        final List<UnrecordedScheduleResponse> result = getUnrecordedScheduleUseCase.invoke(authenticated.id());
+        return ResponseEntity.ok(ResponseWrapper.from(result));
+    }
+}

--- a/src/test/java/ac/dnd/mur/server/acceptance/schedule/GetUnrecordedScheduleAcceptanceTest.java
+++ b/src/test/java/ac/dnd/mur/server/acceptance/schedule/GetUnrecordedScheduleAcceptanceTest.java
@@ -1,0 +1,136 @@
+package ac.dnd.mur.server.acceptance.schedule;
+
+import ac.dnd.mur.server.auth.domain.model.AuthMember;
+import ac.dnd.mur.server.common.AcceptanceTest;
+import ac.dnd.mur.server.common.containers.callback.DatabaseCleanerEachCallbackExtension;
+import ac.dnd.mur.server.group.domain.model.GroupResponse;
+import io.restassured.response.ValidatableResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static ac.dnd.mur.server.acceptance.group.GroupAcceptanceStep.관리하고_있는_특정_그룹의_ID를_조회한다;
+import static ac.dnd.mur.server.acceptance.heart.HeartAcceptanceStep.마음을_생성한다;
+import static ac.dnd.mur.server.acceptance.relation.RelationAcceptanceStep.관계를_생성하고_ID를_추출한다;
+import static ac.dnd.mur.server.acceptance.schedule.ScheduleAcceptanceStep.일정을_생성하고_ID를_추출한다;
+import static ac.dnd.mur.server.acceptance.schedule.ScheduleAcceptanceStep.지출이_기록되지_않은_일정을_조회한다;
+import static ac.dnd.mur.server.common.fixture.MemberFixture.MEMBER_1;
+import static ac.dnd.mur.server.common.fixture.ScheduleFixture.특별한_일정_XXX;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.http.HttpStatus.OK;
+
+@ExtendWith(DatabaseCleanerEachCallbackExtension.class)
+@DisplayName("[Acceptance Test] 지출(보낸 마음)이 기록되지 않은 일정 조회")
+public class GetUnrecordedScheduleAcceptanceTest extends AcceptanceTest {
+    @Nested
+    @DisplayName("지출(보낸 마음)이 기록되지 않은 일정 조회 API")
+    class Create {
+        @Test
+        @DisplayName("지출(보낸 마음)이 기록되지 않은 일정을 조회한다 - UnrecordedStandardDefiner = 2024/01/20")
+        void success() {
+            final AuthMember member = MEMBER_1.회원가입과_로그인을_진행한다();
+            final long groupId = 관리하고_있는_특정_그룹의_ID를_조회한다("친구", member.accessToken());
+            final long relationId1 = 관계를_생성하고_ID를_추출한다(groupId, "관계-친구XXX-1", null, null, member.accessToken());
+            final long relationId2 = 관계를_생성하고_ID를_추출한다(groupId, "관계-친구XXX-2", null, null, member.accessToken());
+            final long relationId3 = 관계를_생성하고_ID를_추출한다(groupId, "관계-친구XXX-3", null, null, member.accessToken());
+            final long scheduleId1 = 일정을_생성하고_ID를_추출한다(
+                    relationId1,
+                    LocalDate.of(2024, 1, 1),
+                    "일정1",
+                    특별한_일정_XXX,
+                    member.accessToken()
+            );
+            final long scheduleId2 = 일정을_생성하고_ID를_추출한다(
+                    relationId2,
+                    LocalDate.of(2024, 1, 15),
+                    "일정2",
+                    특별한_일정_XXX,
+                    member.accessToken()
+            );
+            final long scheduleId3 = 일정을_생성하고_ID를_추출한다(
+                    relationId3,
+                    LocalDate.of(2024, 1, 22),
+                    "일정3",
+                    특별한_일정_XXX,
+                    member.accessToken()
+            );
+
+            final ValidatableResponse response1 = 지출이_기록되지_않은_일정을_조회한다(member.accessToken()).statusCode(OK.value());
+            assertUnrecordedSchedulesMatch(
+                    response1,
+                    List.of(scheduleId1, scheduleId2),
+                    List.of(relationId1, relationId2),
+                    List.of("관계-친구XXX-1", "관계-친구XXX-2"),
+                    List.of(new GroupResponse(groupId, "친구"), new GroupResponse(groupId, "친구")),
+                    List.of(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 15)),
+                    List.of("일정1", "일정2")
+            );
+
+            마음을_생성한다(relationId2, true, 100_000, LocalDate.of(2024, 1, 15), "일정2", null, List.of(), member.accessToken());
+            final ValidatableResponse response2 = 지출이_기록되지_않은_일정을_조회한다(member.accessToken()).statusCode(OK.value());
+            assertUnrecordedSchedulesMatch(
+                    response2,
+                    List.of(scheduleId1),
+                    List.of(relationId1),
+                    List.of("관계-친구XXX-1"),
+                    List.of(new GroupResponse(groupId, "친구")),
+                    List.of(LocalDate.of(2024, 1, 1)),
+                    List.of("일정1")
+            );
+
+            마음을_생성한다(relationId1, true, 100_000, LocalDate.of(2024, 1, 1), "일정1", null, List.of(), member.accessToken());
+            final ValidatableResponse response3 = 지출이_기록되지_않은_일정을_조회한다(member.accessToken()).statusCode(OK.value());
+            assertUnrecordedSchedulesMatch(
+                    response3,
+                    List.of(),
+                    List.of(),
+                    List.of(),
+                    List.of(),
+                    List.of(),
+                    List.of()
+            );
+        }
+    }
+
+    private void assertUnrecordedSchedulesMatch(
+            final ValidatableResponse response,
+            final List<Long> ids,
+            final List<Long> relationIds,
+            final List<String> relationNames,
+            final List<GroupResponse> groups,
+            final List<LocalDate> days,
+            final List<String> events
+    ) {
+        final int totalSize = ids.size();
+        response.body("result", hasSize(totalSize));
+
+        for (int i = 0; i < totalSize; i++) {
+            final String index = String.format("result[%d]", i);
+            final Long id = ids.get(i);
+            final Long relationId = relationIds.get(i);
+            final String relationName = relationNames.get(i);
+            final GroupResponse group = groups.get(i);
+            final LocalDate day = days.get(i);
+            final String event = events.get(i);
+
+            response
+                    .body(index + ".id", is(id.intValue()))
+                    .body(index + ".relation.id", is(relationId.intValue()))
+                    .body(index + ".relation.name", is(relationName))
+                    .body(index + ".relation.group.id", is((int) group.id()))
+                    .body(index + ".relation.group.name", is(group.name()))
+                    .body(index + ".day", is(day.format(DateTimeFormatter.ISO_LOCAL_DATE)))
+                    .body(index + ".event", is(event))
+                    .body(index + ".time", nullValue())
+                    .body(index + ".link", nullValue())
+                    .body(index + ".location", nullValue());
+        }
+    }
+}

--- a/src/test/java/ac/dnd/mur/server/acceptance/schedule/ScheduleAcceptanceStep.java
+++ b/src/test/java/ac/dnd/mur/server/acceptance/schedule/ScheduleAcceptanceStep.java
@@ -6,7 +6,10 @@ import ac.dnd.mur.server.schedule.presentation.dto.request.UpdateScheduleRequest
 import io.restassured.response.ValidatableResponse;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.time.LocalDate;
+
 import static ac.dnd.mur.server.acceptance.CommonRequestFixture.deleteRequestWithAccessToken;
+import static ac.dnd.mur.server.acceptance.CommonRequestFixture.getRequestWithAccessToken;
 import static ac.dnd.mur.server.acceptance.CommonRequestFixture.patchRequestWithAccessToken;
 import static ac.dnd.mur.server.acceptance.CommonRequestFixture.postRequestWithAccessToken;
 
@@ -36,6 +39,48 @@ public class ScheduleAcceptanceStep {
         );
 
         return postRequestWithAccessToken(uri, request, accessToken);
+    }
+
+    public static ValidatableResponse 일정을_생성한다(
+            final long relationId,
+            final LocalDate day,
+            final String event,
+            final ScheduleFixture fixture,
+            final String accessToken
+    ) {
+        final String uri = UriComponentsBuilder
+                .fromPath("/api/v1/schedules")
+                .build()
+                .toUri()
+                .getPath();
+
+        final CreateScheduleRequest request = new CreateScheduleRequest(
+                relationId,
+                day,
+                event,
+                (fixture.getRepeat() != null) ? fixture.getRepeat().getType().getValue() : null,
+                (fixture.getRepeat() != null) ? fixture.getRepeat().getFinish() : null,
+                fixture.getAlarm(),
+                fixture.getTime(),
+                fixture.getLink(),
+                fixture.getLocation(),
+                fixture.getMemo()
+        );
+
+        return postRequestWithAccessToken(uri, request, accessToken);
+    }
+
+    public static long 일정을_생성하고_ID를_추출한다(
+            final long relationId,
+            final LocalDate day,
+            final String event,
+            final ScheduleFixture fixture,
+            final String accessToken
+    ) {
+        return 일정을_생성한다(relationId, day, event, fixture, accessToken)
+                .extract()
+                .jsonPath()
+                .getLong("result");
     }
 
     public static long 일정을_생성하고_ID를_추출한다(
@@ -74,6 +119,33 @@ public class ScheduleAcceptanceStep {
         return patchRequestWithAccessToken(uri, request, accessToken);
     }
 
+    public static ValidatableResponse 일정을_수정한다(
+            final long scheduleId,
+            final LocalDate day,
+            final String event,
+            final ScheduleFixture fixture,
+            final String accessToken
+    ) {
+        final String uri = UriComponentsBuilder
+                .fromPath("/api/v1/schedules/{scheduleId}")
+                .build(scheduleId)
+                .getPath();
+
+        final UpdateScheduleRequest request = new UpdateScheduleRequest(
+                day,
+                event,
+                (fixture.getRepeat() != null) ? fixture.getRepeat().getType().getValue() : null,
+                (fixture.getRepeat() != null) ? fixture.getRepeat().getFinish() : null,
+                fixture.getAlarm(),
+                fixture.getTime(),
+                fixture.getLink(),
+                fixture.getLocation(),
+                fixture.getMemo()
+        );
+
+        return patchRequestWithAccessToken(uri, request, accessToken);
+    }
+
     public static ValidatableResponse 일정을_삭제한다(
             final long scheduleId,
             final String accessToken
@@ -84,5 +156,15 @@ public class ScheduleAcceptanceStep {
                 .getPath();
 
         return deleteRequestWithAccessToken(uri, accessToken);
+    }
+
+    public static ValidatableResponse 지출이_기록되지_않은_일정을_조회한다(final String accessToken) {
+        final String uri = UriComponentsBuilder
+                .fromPath("/api/v1/schedules/unrecorded")
+                .build()
+                .toUri()
+                .getPath();
+
+        return getRequestWithAccessToken(uri, accessToken);
     }
 }

--- a/src/test/java/ac/dnd/mur/server/common/config/BlackboxLogicControlConfig.java
+++ b/src/test/java/ac/dnd/mur/server/common/config/BlackboxLogicControlConfig.java
@@ -1,9 +1,12 @@
 package ac.dnd.mur.server.common.config;
 
 import ac.dnd.mur.server.file.domain.service.BucketFileNameGenerator;
+import ac.dnd.mur.server.schedule.domain.service.UnrecordedStandardDefiner;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
+
+import java.time.LocalDate;
 
 @TestConfiguration
 public class BlackboxLogicControlConfig {
@@ -13,5 +16,11 @@ public class BlackboxLogicControlConfig {
     @Primary
     public BucketFileNameGenerator bucketFileNameGenerator() {
         return fileName -> BUCKET_UPLOAD_PREFIX + fileName;
+    }
+
+    @Bean
+    @Primary
+    public UnrecordedStandardDefiner unrecordedStandardCreator() {
+        return () -> LocalDate.of(2024, 1, 20);
     }
 }

--- a/src/test/java/ac/dnd/mur/server/common/fixture/ScheduleFixture.java
+++ b/src/test/java/ac/dnd/mur/server/common/fixture/ScheduleFixture.java
@@ -25,7 +25,12 @@ public enum ScheduleFixture {
             LocalDate.of(2024, 2, 10), "친구 생일", new Repeat(EVERY_YEAR, null),
             LocalDateTime.of(2024, 2, 10, 9, 0), null,
             null, null, "~~~ 생일"
-    );
+    ),
+    특별한_일정_XXX(
+            LocalDate.of(2024, 1, 1), "특별한 일정 XXX",
+            null, null, null, null, null, null
+    ),
+    ;
 
     private final LocalDate day;
     private final String event;

--- a/src/test/java/ac/dnd/mur/server/group/presentation/ManageGroupApiControllerTest.java
+++ b/src/test/java/ac/dnd/mur/server/group/presentation/ManageGroupApiControllerTest.java
@@ -22,7 +22,6 @@ import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.SnippetF
 import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.SnippetFactory.path;
 import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.createHttpSpecSnippets;
 import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.failureDocsWithAccessToken;
-import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.successDocs;
 import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.successDocsWithAccessToken;
 import static ac.dnd.mur.server.group.exception.GroupExceptionCode.GROUP_ALREADY_EXISTS;
 import static org.mockito.ArgumentMatchers.any;
@@ -203,7 +202,7 @@ class ManageGroupApiControllerTest extends ControllerTest {
             successfulExecute(
                     getRequestWithAccessToken(BASE_URL),
                     status().isOk(),
-                    successDocs("GroupApi/GetMembers", createHttpSpecSnippets(
+                    successDocsWithAccessToken("GroupApi/GetMembers", createHttpSpecSnippets(
                             responseFields(
                                     body("result[].id", "그룹 ID(PK)"),
                                     body("result[].name", "그룹명")

--- a/src/test/java/ac/dnd/mur/server/member/presentation/ManageAccountApiControllerTest.java
+++ b/src/test/java/ac/dnd/mur/server/member/presentation/ManageAccountApiControllerTest.java
@@ -13,7 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import static ac.dnd.mur.server.common.fixture.MemberFixture.MEMBER_1;
 import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.SnippetFactory.body;
 import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.createHttpSpecSnippets;
-import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.successDocs;
 import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.successDocsWithAccessToken;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -52,7 +51,7 @@ class ManageAccountApiControllerTest extends ControllerTest {
             successfulExecute(
                     patchRequestWithAccessToken(BASE_URL, request),
                     status().isNoContent(),
-                    successDocs("MemberApi/Update", createHttpSpecSnippets(
+                    successDocsWithAccessToken("MemberApi/Update", createHttpSpecSnippets(
                             requestFields(
                                     body("profileImageUrl", "프로필 이미지 URL", true),
                                     body("nickname", "닉네임", true),

--- a/src/test/java/ac/dnd/mur/server/relation/presentation/GetRelationDetailsApiControllerTest.java
+++ b/src/test/java/ac/dnd/mur/server/relation/presentation/GetRelationDetailsApiControllerTest.java
@@ -20,7 +20,7 @@ import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.SnippetF
 import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.SnippetFactory.path;
 import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.SnippetFactory.query;
 import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.createHttpSpecSnippets;
-import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.successDocs;
+import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.successDocsWithAccessToken;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -57,7 +57,7 @@ class GetRelationDetailsApiControllerTest extends ControllerTest {
             successfulExecute(
                     getRequestWithAccessToken(new UrlWithVariables(BASE_URL, 1L)),
                     status().isOk(),
-                    successDocs("RelationApi/Details/Single", createHttpSpecSnippets(
+                    successDocsWithAccessToken("RelationApi/Details/Single", createHttpSpecSnippets(
                             pathParameters(
                                     path("relationId", "관계 ID(PK)", true)
                             ),
@@ -94,7 +94,7 @@ class GetRelationDetailsApiControllerTest extends ControllerTest {
             successfulExecute(
                     getRequestWithAccessToken(new UrlWithVariables(BASE_URL, 1L), Map.of("name", "HelloUser")),
                     status().isOk(),
-                    successDocs("RelationApi/Details/Multiple", createHttpSpecSnippets(
+                    successDocsWithAccessToken("RelationApi/Details/Multiple", createHttpSpecSnippets(
                             queryParameters(
                                     query("name", "검색할 이름", "관계 등록할 때 적용한 이름으로 조회", false)
                             ),

--- a/src/test/java/ac/dnd/mur/server/schedule/presentation/GetUnrecordedScheduleApiControllerTest.java
+++ b/src/test/java/ac/dnd/mur/server/schedule/presentation/GetUnrecordedScheduleApiControllerTest.java
@@ -1,0 +1,81 @@
+package ac.dnd.mur.server.schedule.presentation;
+
+import ac.dnd.mur.server.common.ControllerTest;
+import ac.dnd.mur.server.group.domain.model.GroupResponse;
+import ac.dnd.mur.server.member.domain.model.Member;
+import ac.dnd.mur.server.schedule.application.usecase.GetUnrecordedScheduleUseCase;
+import ac.dnd.mur.server.schedule.application.usecase.query.response.UnrecordedScheduleResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static ac.dnd.mur.server.common.fixture.GroupFixture.친구;
+import static ac.dnd.mur.server.common.fixture.MemberFixture.MEMBER_1;
+import static ac.dnd.mur.server.common.fixture.RelationFixture.친구_1;
+import static ac.dnd.mur.server.common.fixture.ScheduleFixture.친구_XXX_생일;
+import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.SnippetFactory.body;
+import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.createHttpSpecSnippets;
+import static ac.dnd.mur.server.common.utils.RestDocsSpecificationUtils.successDocsWithAccessToken;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Schedule -> GetUnrecordedScheduleApiController 테스트")
+class GetUnrecordedScheduleApiControllerTest extends ControllerTest {
+    @Autowired
+    private GetUnrecordedScheduleUseCase getUnrecordedScheduleUseCase;
+
+    private final Member member = MEMBER_1.toDomain().apply(1L);
+
+    @Nested
+    @DisplayName("지출(보낸 마음)이 기록되지 않은 일정 조회 API [GET /api/v1/schedules/unrecorded]")
+    class GetUnrecordedSchedule {
+        private static final String BASE_URL = "/api/v1/schedules/unrecorded";
+
+        @Test
+        @DisplayName("지출(보낸 마음)이 기록되지 않은 일정을 조회한다")
+        void success() {
+            // given
+            applyToken(true, member);
+            given(getUnrecordedScheduleUseCase.invoke(member.getId())).willReturn(List.of(
+                    new UnrecordedScheduleResponse(
+                            10L,
+                            new UnrecordedScheduleResponse.RelationSummary(
+                                    1L,
+                                    친구_1.getName(),
+                                    new GroupResponse(1L, 친구.getName())
+                            ),
+                            LocalDate.of(2024, 1, 31),
+                            친구_XXX_생일.getEvent(),
+                            친구_XXX_생일.getTime(),
+                            친구_XXX_생일.getLink(),
+                            친구_XXX_생일.getLocation()
+                    )
+            ));
+
+            // when - then
+            successfulExecute(
+                    getRequestWithAccessToken(new UrlWithVariables(BASE_URL, 1L)),
+                    status().isOk(),
+                    successDocsWithAccessToken("ScheduleApi/UnrecordedHeart", createHttpSpecSnippets(
+                            responseFields(
+                                    body("result[].id", "일정 ID(PK)"),
+                                    body("result[].relation.id", "관계 ID(PK)"),
+                                    body("result[].relation.name", "관계 이름"),
+                                    body("result[].relation.group.id", "그룹 ID(PK)"),
+                                    body("result[].relation.group.name", "그룹명"),
+                                    body("result[].day", "날짜"),
+                                    body("result[].event", "행사 종류"),
+                                    body("result[].time", "시간", "Nullable"),
+                                    body("result[].link", "링크", "Nullable"),
+                                    body("result[].location", "위치", "Nullable")
+                            )
+                    ))
+            );
+        }
+    }
+}


### PR DESCRIPTION
# Summary

- 지출이 기록되지 않은 일정 조회 API 구현
  - 현재 날짜로부터 `하루`가 지난 일정이 타겟
  - `relationId + day + event` 기준 공통 요소 필터링

## Related Issue

> Close #47

